### PR TITLE
#49 Handle missing optional multi-value query param

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,65 +104,41 @@ https://github.com/lsd-consulting/spring-wiremock-stub-generator-example
 ## Multi-value request parameters
 
 ### The problem
-According to the accepted answer [here](https://stackoverflow.com/questions/24059773/correct-way-to-pass-multiple-values-for-same-parameter-name-in-get-request) 
-and [this Wiki page](https://en.wikipedia.org/wiki/Query_string) :
-```text
-While there is no definitive standard, most web frameworks allow multiple values to be associated with a single field (e.g. field1=value1&field1=value2&field2=value3).
+This library follows WireMock's approach to handling multiple-value query parameters.
+
+This means multiple values should be passed like this:
+```
+field1=value1&field1=value2&field2=value3
 ```
 
-However, according to [this thread](https://github.com/wiremock/wiremock/issues/398), WireMock doesn't support duplicate query names.
-
-Since Spring MVC does provide handling of duplicate query params out of the box, eg.
+A stub handling the above will be generated from a mapping like this:
 ```kotlin
     @GetMapping("/resourceWithParamSet")
-    fun resourceWithParamSet(@RequestParam paramSet: Set<String>) {
+    fun resourceWithParamSet(@RequestParam field1: Set<String>, @RequestParam field2: String) {
         ...
     }
 ```
 
-there is no easy way to set up a WireMock stub for the above, or similar, examples.
+## Optional multi-value request parameters
+
+### The problem
+
+While WireMock supports multiple-value query parameters as well as optional query parameters, it doesn't yet support
+optional multiple-value query parameters. There is no easy way to set up a WireMock stub for the following mapping:.
+```kotlin
+    @GetMapping("/resourceWithParamSet")
+    fun resourceWithParamSet(@RequestParam(required = false) field1: Set<String>) {
+        ...
+    }
+```
 
 ### The implemented solution
 The library handles queries like this in a special way.
 
-As soon as a multi-value query parameter is detected, the WireMock stub is switched from `urlPathEqualTo` matcher, to the `urlEqualTo` one.
+As soon as an optional multi-value query parameter is detected, the WireMock stub is switched from `urlPathEqualTo` matcher, to the `urlEqualTo` one.
 The implication is that the ordering of the request parameters becomes significant.
 
 Therefore, it is important to use ordered collections when sending multi-value parameters in tests to make the queries deterministic.
-
-## Optional request parameters
-Optional request parameters is another feature of the HTTP protocol that is not yet supported by WireMock (see [here](https://groups.google.com/g/wiremock-user/c/WKMkb_LhJTU)).
-
-To handle the following SpringMVC definition:
-```kotlin
-    @GetMapping("/resourceWithOptionalBooleanRequestParam")
-    fun resourceWithOptionalBooleanRequestParam(@RequestParam(required = false) param: Boolean) {
-        ...
-    }
-```
-the library introduces conditions into the generated stub.
-
-If a parameter is optional and the value passed in is a `null`, the generated stub will not add the query param matcher to the Wiremock stub.
-
-This means that the following call to the generated stub:
-```kotlin
-underTest.resourceWithOptionalBooleanRequestParam(response, null)
-```
-
-will generate a WireMock matcher to match the following GET request:
-```
-/resourceWithOptionalBooleanRequestParam
-```
-
-But if a value is passed in that call, eg:
-```kotlin
-underTest.resourceWithOptionalBooleanRequestParam(response, "value")
-```
-
-then WireMock will expect the following request:
-```
-/resourceWithOptionalBooleanRequestParam?param=value
-```
 
 ## Handling @DateTimeFormat
 If the request parameter or path variable is a date, it needs to be annotated with `@DateTimeFormat`, eg:

--- a/generator-integration-test/src/main/kotlin/com/lsdconsulting/stub/integration/controller/get/GetRestController.kt
+++ b/generator-integration-test/src/main/kotlin/com/lsdconsulting/stub/integration/controller/get/GetRestController.kt
@@ -121,10 +121,10 @@ class GetRestController {
     @Suppress("UNUSED_PARAMETER")
     @GetMapping("/resourceWithOptionalMultiValueRequestParams")
     fun resourceWithOptionalMultiValueRequestParams(
-        @RequestParam required: Boolean,
-        @RequestParam(required = false) optional: Int,
-        @RequestParam multiValue: Set<Int>,
         @RequestParam(name = "parameter4", required = false) optionalMultiValue: Set<Int>,
+        @RequestParam(required = false) optional: Int,
+        @RequestParam required: Boolean,
+        @RequestParam multiValue: Set<Int>,
     ) = GreetingResponse(name = secure().nextAlphabetic(10))
 
     @Suppress("UNUSED_PARAMETER")

--- a/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/get/GetRestControllerStandardResponseIT.kt
+++ b/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/get/GetRestControllerStandardResponseIT.kt
@@ -8,7 +8,6 @@ import com.lsdconsulting.stub.integration.controller.get.GetRestControllerStub
 import com.lsdconsulting.stub.integration.model.GreetingResponse
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.core.ParameterizedTypeReference
@@ -499,7 +498,6 @@ class GetRestControllerStandardResponseIT : BaseRestControllerIT() {
     }
 
     @Test
-    @Disabled
     fun `should handle get mapping with missing optional multi-value request params`() {
         underTest.verifyResourceWithOptionalMultiValueRequestParamsNoInteraction(true, null, setOf(33, 44), null)
         underTest.resourceWithOptionalMultiValueRequestParams(greetingResponse, true, null, setOf(33, 44), null)

--- a/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/get/GetRestControllerStandardResponseIT.kt
+++ b/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/get/GetRestControllerStandardResponseIT.kt
@@ -8,7 +8,6 @@ import com.lsdconsulting.stub.integration.controller.get.GetRestControllerStub
 import com.lsdconsulting.stub.integration.model.GreetingResponse
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.core.ParameterizedTypeReference
@@ -513,7 +512,7 @@ class GetRestControllerStandardResponseIT : BaseRestControllerIT() {
 
         assertThat(response.body, notNullValue())
         assertThat(response.body?.name, `is`(name))
-        underTest.verifyResourceWithOptionalMultiValueRequestParams(1,  setOf(11, 22), 5, true, setOf(33, 44),)
+        underTest.verifyResourceWithOptionalMultiValueRequestParams(1,  setOf(11, 22), 5, true, setOf(33, 44))
         underTest.verifyResourceWithOptionalMultiValueRequestParams(setOf(11, 22), 5, true, setOf(33, 44))
         assertThrows<VerificationException> { underTest.verifyResourceWithOptionalMultiValueRequestParamsNoInteraction(setOf(11, 22), 5, true, setOf(33, 44)) }
     }
@@ -532,13 +531,12 @@ class GetRestControllerStandardResponseIT : BaseRestControllerIT() {
         }
 
         // But the verification still passes
-        underTest.verifyResourceWithOptionalMultiValueRequestParams(1,  setOf(11, 22), 5, true, setOf(33, 44),)
+        underTest.verifyResourceWithOptionalMultiValueRequestParams(1,  setOf(11, 22), 5, true, setOf(33, 44))
         underTest.verifyResourceWithOptionalMultiValueRequestParams(setOf(11, 22), 5, true, setOf(33, 44))
         assertThrows<VerificationException> { underTest.verifyResourceWithOptionalMultiValueRequestParamsNoInteraction(setOf(11, 22), 5, true, setOf(33, 44)) }
     }
 
     @Test
-    @Disabled
     fun `should handle get mapping with missing optional multi-value request params`() {
         underTest.verifyResourceWithOptionalMultiValueRequestParamsNoInteraction(null, null, true, setOf(33, 44))
         underTest.resourceWithOptionalMultiValueRequestParams(greetingResponse, null, null, true, setOf(33, 44))

--- a/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/get/GetRestControllerStandardResponseIT.kt
+++ b/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/get/GetRestControllerStandardResponseIT.kt
@@ -462,6 +462,25 @@ class GetRestControllerStandardResponseIT : BaseRestControllerIT() {
     }
 
     @Test
+    fun `should handle get mapping with empty optional int request params - different order`() {
+        underTest.verifyResourceWithOptionalIntRequestParamsNoInteraction(true, null, null, 11L)
+        underTest.verifyResourceWithOptionalIntRequestParamsNoInteraction()
+        underTest.resourceWithOptionalIntRequestParams(greetingResponse, true, null, null, 11L)
+
+        val response = restTemplate.exchange(
+            "$GET_CONTROLLER_URL/resourceWithOptionalIntRequestParams?parameter4=11&param1=true",
+            GET, HttpEntity(mapOf<String, String>()), GreetingResponse::class.java
+        )
+
+        assertThat(response.body, notNullValue())
+        assertThat(response.body?.name, `is`(name))
+        underTest.verifyResourceWithOptionalIntRequestParams(1, true, null, null, 11L)
+        underTest.verifyResourceWithOptionalIntRequestParams(true, null, null, 11L)
+        assertThrows<VerificationException> { underTest.verifyResourceWithOptionalIntRequestParamsNoInteraction(true, null, null, 11L) }
+        assertThrows<VerificationException> { underTest.verifyResourceWithOptionalIntRequestParamsNoInteraction() }
+    }
+
+    @Test
     fun `should handle get mapping with optional int request params`() {
         underTest.verifyResourceWithOptionalIntRequestParamsNoInteraction(true, 5, 7, 11L)
         underTest.verifyResourceWithOptionalIntRequestParamsNoInteraction()
@@ -498,12 +517,46 @@ class GetRestControllerStandardResponseIT : BaseRestControllerIT() {
     }
 
     @Test
+    fun `should handle get mapping with optional and multi-value request params - different order`() {
+        underTest.verifyResourceWithOptionalMultiValueRequestParamsNoInteraction(setOf(11, 22), 5, true, setOf(33, 44))
+        underTest.resourceWithOptionalMultiValueRequestParams(greetingResponse, setOf(11, 22), 5, true, setOf(33, 44))
+
+        val response = restTemplate.exchange(
+            "$GET_CONTROLLER_URL/resourceWithOptionalMultiValueRequestParams?optional=5&multiValue=33&multiValue=44&parameter4=11&parameter4=22&required=true",
+            GET, HttpEntity(mapOf<String, String>()), GreetingResponse::class.java
+        )
+
+        assertThat(response.body, notNullValue())
+        assertThat(response.body?.name, `is`(name))
+        underTest.verifyResourceWithOptionalMultiValueRequestParams(1,  setOf(11, 22), 5, true, setOf(33, 44),)
+        underTest.verifyResourceWithOptionalMultiValueRequestParams(setOf(11, 22), 5, true, setOf(33, 44))
+        assertThrows<VerificationException> { underTest.verifyResourceWithOptionalMultiValueRequestParamsNoInteraction(setOf(11, 22), 5, true, setOf(33, 44)) }
+    }
+
+    @Test
     fun `should handle get mapping with missing optional multi-value request params`() {
         underTest.verifyResourceWithOptionalMultiValueRequestParamsNoInteraction(null, null, true, setOf(33, 44))
         underTest.resourceWithOptionalMultiValueRequestParams(greetingResponse, null, null, true, setOf(33, 44))
 
         val response = restTemplate.exchange(
             "$GET_CONTROLLER_URL/resourceWithOptionalMultiValueRequestParams?required=true&multiValue=33&multiValue=44",
+            GET, HttpEntity(mapOf<String, String>()), GreetingResponse::class.java
+        )
+
+        assertThat(response.body, notNullValue())
+        assertThat(response.body?.name, `is`(name))
+        underTest.verifyResourceWithOptionalMultiValueRequestParams(1, null, null, true, setOf(33, 44))
+        underTest.verifyResourceWithOptionalMultiValueRequestParams(null, null, true, setOf(33, 44))
+        assertThrows<VerificationException> { underTest.verifyResourceWithOptionalMultiValueRequestParamsNoInteraction(null, null, true, setOf(33, 44)) }
+    }
+
+    @Test
+    fun `should handle get mapping with missing optional multi-value request params - different order`() {
+        underTest.verifyResourceWithOptionalMultiValueRequestParamsNoInteraction(null, null, true, setOf(33, 44))
+        underTest.resourceWithOptionalMultiValueRequestParams(greetingResponse, null, null, true, setOf(33, 44))
+
+        val response = restTemplate.exchange(
+            "$GET_CONTROLLER_URL/resourceWithOptionalMultiValueRequestParams?multiValue=33&multiValue=44&required=true",
             GET, HttpEntity(mapOf<String, String>()), GreetingResponse::class.java
         )
 

--- a/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/get/GetRestControllerStandardResponseIT.kt
+++ b/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/get/GetRestControllerStandardResponseIT.kt
@@ -482,8 +482,8 @@ class GetRestControllerStandardResponseIT : BaseRestControllerIT() {
 
     @Test
     fun `should handle get mapping with optional and multi-value request params`() {
-        underTest.verifyResourceWithOptionalMultiValueRequestParamsNoInteraction(true, 5, setOf(33, 44), setOf(11, 22))
-        underTest.resourceWithOptionalMultiValueRequestParams(greetingResponse, true, 5, setOf(33, 44), setOf(11, 22))
+        underTest.verifyResourceWithOptionalMultiValueRequestParamsNoInteraction(setOf(11, 22), 5, true, setOf(33, 44))
+        underTest.resourceWithOptionalMultiValueRequestParams(greetingResponse, setOf(11, 22), 5, true, setOf(33, 44))
 
         val response = restTemplate.exchange(
             "$GET_CONTROLLER_URL/resourceWithOptionalMultiValueRequestParams?required=true&optional=5&multiValue=33&multiValue=44&parameter4=11&parameter4=22",
@@ -492,15 +492,15 @@ class GetRestControllerStandardResponseIT : BaseRestControllerIT() {
 
         assertThat(response.body, notNullValue())
         assertThat(response.body?.name, `is`(name))
-        underTest.verifyResourceWithOptionalMultiValueRequestParams(1, true, 5, setOf(33, 44), setOf(11, 22))
-        underTest.verifyResourceWithOptionalMultiValueRequestParams(true, 5, setOf(33, 44), setOf(11, 22))
-        assertThrows<VerificationException> { underTest.verifyResourceWithOptionalMultiValueRequestParamsNoInteraction(true, 5, setOf(33, 44), setOf(11, 22)) }
+        underTest.verifyResourceWithOptionalMultiValueRequestParams(1,  setOf(11, 22), 5, true, setOf(33, 44),)
+        underTest.verifyResourceWithOptionalMultiValueRequestParams(setOf(11, 22), 5, true, setOf(33, 44))
+        assertThrows<VerificationException> { underTest.verifyResourceWithOptionalMultiValueRequestParamsNoInteraction(setOf(11, 22), 5, true, setOf(33, 44)) }
     }
 
     @Test
     fun `should handle get mapping with missing optional multi-value request params`() {
-        underTest.verifyResourceWithOptionalMultiValueRequestParamsNoInteraction(true, null, setOf(33, 44), null)
-        underTest.resourceWithOptionalMultiValueRequestParams(greetingResponse, true, null, setOf(33, 44), null)
+        underTest.verifyResourceWithOptionalMultiValueRequestParamsNoInteraction(null, null, true, setOf(33, 44))
+        underTest.resourceWithOptionalMultiValueRequestParams(greetingResponse, null, null, true, setOf(33, 44))
 
         val response = restTemplate.exchange(
             "$GET_CONTROLLER_URL/resourceWithOptionalMultiValueRequestParams?required=true&multiValue=33&multiValue=44",
@@ -509,8 +509,8 @@ class GetRestControllerStandardResponseIT : BaseRestControllerIT() {
 
         assertThat(response.body, notNullValue())
         assertThat(response.body?.name, `is`(name))
-        underTest.verifyResourceWithOptionalMultiValueRequestParams(1, true, null, setOf(33, 44), null)
-        underTest.verifyResourceWithOptionalMultiValueRequestParams(true, null, setOf(33, 44), null)
-        assertThrows<VerificationException> { underTest.verifyResourceWithOptionalMultiValueRequestParamsNoInteraction(true, null, setOf(33, 44), null) }
+        underTest.verifyResourceWithOptionalMultiValueRequestParams(1, null, null, true, setOf(33, 44))
+        underTest.verifyResourceWithOptionalMultiValueRequestParams(null, null, true, setOf(33, 44))
+        assertThrows<VerificationException> { underTest.verifyResourceWithOptionalMultiValueRequestParamsNoInteraction(null, null, true, setOf(33, 44)) }
     }
 }

--- a/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/get/JavaGetRestControllerIT.kt
+++ b/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/get/JavaGetRestControllerIT.kt
@@ -57,8 +57,7 @@ class JavaGetRestControllerIT : BaseRestControllerIT() {
         underTest.resourceWithZonedDatetimeAndMultiValue(greetingResponse, param, setOf(33, 44))
 
         val request = HttpGet(
-            "$GET_CONTROLLER_URL/resourceWithZonedDatetimeAndMultiValue?param=${param.format(DateTimeFormatter.ISO_DATE_TIME)
-            }&multiValue=33&multiValue=44"
+            "$GET_CONTROLLER_URL/resourceWithZonedDatetimeAndMultiValue?param=${param.format(DateTimeFormatter.ISO_DATE_TIME).replace("+", "%2B")}&multiValue=33&multiValue=44"
         )
         HttpClients.createDefault().use { client -> client.execute(request) { } }
 

--- a/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/get/JavaGetRestControllerIT.should remove unwanted annotations from any arguments.approved
+++ b/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/get/JavaGetRestControllerIT.should remove unwanted annotations from any arguments.approved
@@ -44,23 +44,31 @@ public class JavaGetRestControllerStub {
     public void resourceWithZonedDatetimeAndMultiValue(com.lsdconsulting.stub.integration.model.GreetingResponse response, java.time.ZonedDateTime param, java.util.Set<java.lang.Integer> multiValue) {
         String url = String.format(RESOURCEWITHZONEDDATETIMEANDMULTIVALUE_URL);
         MappingBuilder mappingBuilder = get(urlPathEqualTo(url));
-                                            url = url + "?";
+                        if (param != null) {
+                    url = url + "?";
                                             url = url + "param=" + serialise(param, "java.time.ZonedDateTime", "DATE_TIME", "", "SS", "");
-                                            url = url + "&";
+                    }
+    if (multiValue != null) {
+                    url = url + "&";
                             url = url + "multiValue=";
                             url = url + String.join("&multiValue=", multiValue.stream().map(x -> x.toString()).collect(toList()));
-                                    stub(OK, buildBody(response), mappingBuilder);
+                    }
+                stub(OK, buildBody(response), mappingBuilder);
             }
 
     
     public void resourceWithZonedDatetimeAndMultiValue(int httpStatus, String response, java.time.ZonedDateTime param, java.util.Set<java.lang.Integer> multiValue) {
         String url = String.format(RESOURCEWITHZONEDDATETIMEANDMULTIVALUE_URL);
-                                            url = url + "?";
+                        if (param != null) {
+                    url = url + "?";
                                             url = url + "param=" + serialise(param, "java.time.ZonedDateTime", "DATE_TIME", "", "SS", "");
-                                            url = url + "&";
+                    }
+    if (multiValue != null) {
+                    url = url + "&";
                             url = url + "multiValue=";
                             url = url + String.join("&multiValue=", multiValue.stream().map(x -> x.toString()).collect(toList()));
-                                    stub(httpStatus, response, get(urlEqualTo(url)));
+                    }
+                stub(httpStatus, response, get(urlEqualTo(url)));
             }
 
     public void verifyResourceWithZonedDatetimeAndMultiValue(java.time.ZonedDateTime param, java.util.Set<java.lang.Integer> multiValue) {
@@ -69,24 +77,32 @@ public class JavaGetRestControllerStub {
 
     public void verifyResourceWithZonedDatetimeAndMultiValue(final int times, java.time.ZonedDateTime param, java.util.Set<java.lang.Integer> multiValue) {
         String url = String.format(RESOURCEWITHZONEDDATETIMEANDMULTIVALUE_URL);
-                                            url = url + "?";
+                        if (param != null) {
+                    url = url + "?";
                                             url = url + "param=" + serialise(param, "java.time.ZonedDateTime", "DATE_TIME", "", "SS", "");
-                                            url = url + "&";
+                    }
+    if (multiValue != null) {
+                    url = url + "&";
                             url = url + "multiValue=";
                             url = url + String.join("&multiValue=", multiValue.stream().map(x -> x.toString()).collect(toList()));
-                                    verify(times, getRequestedFor(urlEqualTo(url))
+                    }
+                verify(times, getRequestedFor(urlEqualTo(url))
                             );
             }
 
     
     public void verifyResourceWithZonedDatetimeAndMultiValueNoInteraction(java.time.ZonedDateTime param, java.util.Set<java.lang.Integer> multiValue) {
         String url = String.format(RESOURCEWITHZONEDDATETIMEANDMULTIVALUE_URL);
-                                            url = url + "?";
+                        if (param != null) {
+                    url = url + "?";
                                             url = url + "param=" + serialise(param, "java.time.ZonedDateTime", "DATE_TIME", "", "SS", "");
-                                            url = url + "&";
+                    }
+    if (multiValue != null) {
+                    url = url + "&";
                             url = url + "multiValue=";
                             url = url + String.join("&multiValue=", multiValue.stream().map(x -> x.toString()).collect(toList()));
-                                    verify(NEVER, getRequestedFor(urlEqualTo(url))
+                    }
+                verify(NEVER, getRequestedFor(urlEqualTo(url))
                             );
             }
 

--- a/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/get/JavaGetRestControllerIT.should remove unwanted annotations from any arguments.approved
+++ b/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/get/JavaGetRestControllerIT.should remove unwanted annotations from any arguments.approved
@@ -43,32 +43,25 @@ public class JavaGetRestControllerStub {
 
     public void resourceWithZonedDatetimeAndMultiValue(com.lsdconsulting.stub.integration.model.GreetingResponse response, java.time.ZonedDateTime param, java.util.Set<java.lang.Integer> multiValue) {
         String url = String.format(RESOURCEWITHZONEDDATETIMEANDMULTIVALUE_URL);
-        MappingBuilder mappingBuilder = get(urlPathEqualTo(url));
-                        if (param != null) {
-                    url = url + "?";
-                                            url = url + "param=" + serialise(param, "java.time.ZonedDateTime", "DATE_TIME", "", "SS", "");
-                    }
-    if (multiValue != null) {
-                    url = url + "&";
-                            url = url + "multiValue=";
-                            url = url + String.join("&multiValue=", multiValue.stream().map(x -> x.toString()).collect(toList()));
-                    }
-                stub(OK, buildBody(response), mappingBuilder);
+                    MappingBuilder mappingBuilder = get(urlPathEqualTo(url));
+                        
+                                                mappingBuilder.withQueryParam("param", equalTo(serialise(param, "java.time.ZonedDateTime", "DATE_TIME", "", "SS", "")));
+                            
+                                                mappingBuilder.withQueryParam("multiValue", havingExactly(multiValue.stream().map(x -> x.toString()).toArray(String[]::new)));
+            
+                        stub(OK, buildBody(response), mappingBuilder);
             }
 
     
     public void resourceWithZonedDatetimeAndMultiValue(int httpStatus, String response, java.time.ZonedDateTime param, java.util.Set<java.lang.Integer> multiValue) {
         String url = String.format(RESOURCEWITHZONEDDATETIMEANDMULTIVALUE_URL);
-                        if (param != null) {
-                    url = url + "?";
-                                            url = url + "param=" + serialise(param, "java.time.ZonedDateTime", "DATE_TIME", "", "SS", "");
-                    }
-    if (multiValue != null) {
-                    url = url + "&";
-                            url = url + "multiValue=";
-                            url = url + String.join("&multiValue=", multiValue.stream().map(x -> x.toString()).collect(toList()));
-                    }
-                stub(httpStatus, response, get(urlEqualTo(url)));
+                    MappingBuilder mappingBuilder = get(urlPathEqualTo(url));
+                    
+                                                mappingBuilder.withQueryParam("param", equalTo(serialise(param, "java.time.ZonedDateTime", "DATE_TIME", "", "SS", "")));
+                            
+                                                mappingBuilder.withQueryParam("multiValue", havingExactly(multiValue.stream().map(x -> x.toString()).toArray(String[]::new)));
+            
+                        stub(httpStatus, response, mappingBuilder);
             }
 
     public void verifyResourceWithZonedDatetimeAndMultiValue(java.time.ZonedDateTime param, java.util.Set<java.lang.Integer> multiValue) {
@@ -80,8 +73,7 @@ public class JavaGetRestControllerStub {
         RequestPatternBuilder requestPatternBuilder = getRequestedFor(urlPathEqualTo(url));
                                                                 requestPatternBuilder.withQueryParam("param", equalTo(serialise(param, "java.time.ZonedDateTime", "DATE_TIME", "", "SS", "")));
                                                                         requestPatternBuilder.withQueryParam("multiValue", havingExactly(multiValue.stream().map(x -> x.toString()).toArray(String[]::new)));
-                                            verify(times, requestPatternBuilder
-                            );
+                                                                        verify(times, requestPatternBuilder);
             }
 
     
@@ -90,25 +82,32 @@ public class JavaGetRestControllerStub {
         RequestPatternBuilder requestPatternBuilder = getRequestedFor(urlPathEqualTo(url));
                                                                 requestPatternBuilder.withQueryParam("param", equalTo(serialise(param, "java.time.ZonedDateTime", "DATE_TIME", "", "SS", "")));
                                                                         requestPatternBuilder.withQueryParam("multiValue", havingExactly(multiValue.stream().map(x -> x.toString()).toArray(String[]::new)));
-                                            verify(NEVER, requestPatternBuilder
-                            );
+                                                                        verify(NEVER, requestPatternBuilder);
             }
 
+        public void verifyResourceWithZonedDatetimeAndMultiValueNoInteraction() {
+        String url = String.format(RESOURCEWITHZONEDDATETIMEANDMULTIVALUE_URL);
+        verify(NEVER, getRequestedFor(urlPathEqualTo(url)));
+    }
         public static final String RESOURCEWITHPARAMANDANNOTATIONS_URL = "/getController/resourceWithParamAndAnnotations";
 
     public void resourceWithParamAndAnnotations(com.lsdconsulting.stub.integration.model.GreetingResponse response, java.lang.String param) {
         String url = String.format(RESOURCEWITHPARAMANDANNOTATIONS_URL);
-        MappingBuilder mappingBuilder = get(urlPathEqualTo(url));
-                                                            mappingBuilder.withQueryParam("param", equalTo(String.valueOf(param)));
-                                    stub(OK, buildBody(response), mappingBuilder);
+                    MappingBuilder mappingBuilder = get(urlPathEqualTo(url));
+                        
+                                                mappingBuilder.withQueryParam("param", equalTo(String.valueOf(param)));
+                            
+                        stub(OK, buildBody(response), mappingBuilder);
             }
 
     
     public void resourceWithParamAndAnnotations(int httpStatus, String response, java.lang.String param) {
         String url = String.format(RESOURCEWITHPARAMANDANNOTATIONS_URL);
                     MappingBuilder mappingBuilder = get(urlPathEqualTo(url));
+                    
                                                 mappingBuilder.withQueryParam("param", equalTo(String.valueOf(param)));
-                                    stub(httpStatus, response, mappingBuilder);
+                            
+                        stub(httpStatus, response, mappingBuilder);
             }
 
     public void verifyResourceWithParamAndAnnotations(java.lang.String param) {

--- a/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/get/JavaGetRestControllerIT.should remove unwanted annotations from any arguments.approved
+++ b/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/get/JavaGetRestControllerIT.should remove unwanted annotations from any arguments.approved
@@ -77,30 +77,22 @@ public class JavaGetRestControllerStub {
 
     public void verifyResourceWithZonedDatetimeAndMultiValue(final int times, java.time.ZonedDateTime param, java.util.Set<java.lang.Integer> multiValue) {
         String url = String.format(RESOURCEWITHZONEDDATETIMEANDMULTIVALUE_URL);
-        RequestPatternBuilder requestedFor = getRequestedFor(urlPathEqualTo(url));
-                        if (param != null) {
-                                requestedFor.withQueryParam("param", equalTo(serialise(param, "java.time.ZonedDateTime", "DATE_TIME", "", "SS", "")));
-                    }
-    if (multiValue != null) {
-                    url = url + "multiValue=";
-                        requestedFor.withQueryParam("multiValue", havingExactly(multiValue.stream().map(x -> x.toString()).toArray(String[]::new)));
-                    }
-                verify(times, requestedFor
+        RequestPatternBuilder requestPatternBuilder = getRequestedFor(urlPathEqualTo(url));
+                                                                requestPatternBuilder.withQueryParam("param", equalTo(serialise(param, "java.time.ZonedDateTime", "DATE_TIME", "", "SS", "")));
+                                                            url = url + "multiValue=";
+                        requestPatternBuilder.withQueryParam("multiValue", havingExactly(multiValue.stream().map(x -> x.toString()).toArray(String[]::new)));
+                                            verify(times, requestPatternBuilder
                             );
             }
 
     
     public void verifyResourceWithZonedDatetimeAndMultiValueNoInteraction(java.time.ZonedDateTime param, java.util.Set<java.lang.Integer> multiValue) {
         String url = String.format(RESOURCEWITHZONEDDATETIMEANDMULTIVALUE_URL);
-        RequestPatternBuilder requestedFor = getRequestedFor(urlPathEqualTo(url));
-                        if (param != null) {
-                                requestedFor.withQueryParam("param", equalTo(serialise(param, "java.time.ZonedDateTime", "DATE_TIME", "", "SS", "")));
-                    }
-    if (multiValue != null) {
-                    url = url + "multiValue=";
-                        requestedFor.withQueryParam("multiValue", havingExactly(multiValue.stream().map(x -> x.toString()).toArray(String[]::new)));
-                    }
-                verify(NEVER, requestedFor
+        RequestPatternBuilder requestPatternBuilder = getRequestedFor(urlPathEqualTo(url));
+                                                                requestPatternBuilder.withQueryParam("param", equalTo(serialise(param, "java.time.ZonedDateTime", "DATE_TIME", "", "SS", "")));
+                                                            url = url + "multiValue=";
+                        requestPatternBuilder.withQueryParam("multiValue", havingExactly(multiValue.stream().map(x -> x.toString()).toArray(String[]::new)));
+                                            verify(NEVER, requestPatternBuilder
                             );
             }
 
@@ -127,19 +119,17 @@ public class JavaGetRestControllerStub {
 
     public void verifyResourceWithParamAndAnnotations(final int times, java.lang.String param) {
         String url = String.format(RESOURCEWITHPARAMANDANNOTATIONS_URL);
-        RequestPatternBuilder requestedFor = getRequestedFor(urlPathEqualTo(url));
-                    RequestPatternBuilder requestPatternBuilder = getRequestedFor(urlPathEqualTo(format(url)));
-                                            requestPatternBuilder.withQueryParam("param", equalTo(String.valueOf(param)));
-                                                            verify(times, requestPatternBuilder);
+        RequestPatternBuilder requestPatternBuilder = getRequestedFor(urlPathEqualTo(url));
+                                                                requestPatternBuilder.withQueryParam("param", equalTo(String.valueOf(param)));
+                                                                        verify(times, requestPatternBuilder);
             }
 
     
     public void verifyResourceWithParamAndAnnotationsNoInteraction(java.lang.String param) {
         String url = String.format(RESOURCEWITHPARAMANDANNOTATIONS_URL);
-        RequestPatternBuilder requestedFor = getRequestedFor(urlPathEqualTo(url));
-                    RequestPatternBuilder requestPatternBuilder = getRequestedFor(urlPathEqualTo(format(url)));
-                                            requestPatternBuilder.withQueryParam("param", equalTo(String.valueOf(param)));
-                                                            verify(NEVER, requestPatternBuilder);
+        RequestPatternBuilder requestPatternBuilder = getRequestedFor(urlPathEqualTo(url));
+                                                                requestPatternBuilder.withQueryParam("param", equalTo(String.valueOf(param)));
+                                                                        verify(NEVER, requestPatternBuilder);
             }
 
         public void verifyResourceWithParamAndAnnotationsNoInteraction() {
@@ -210,7 +200,6 @@ public class JavaGetRestControllerStub {
         }
     }
 }
-
 
 
 

--- a/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/get/JavaGetRestControllerIT.should remove unwanted annotations from any arguments.approved
+++ b/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/get/JavaGetRestControllerIT.should remove unwanted annotations from any arguments.approved
@@ -47,7 +47,7 @@ public class JavaGetRestControllerStub {
                         
                                                 mappingBuilder.withQueryParam("param", equalTo(serialise(param, "java.time.ZonedDateTime", "DATE_TIME", "", "SS", "")));
                             
-                                                mappingBuilder.withQueryParam("multiValue", havingExactly(multiValue.stream().map(x -> x.toString()).toArray(String[]::new)));
+                                                            mappingBuilder.withQueryParam("multiValue", havingExactly(multiValue.stream().map(x -> x.toString()).toArray(String[]::new)));
             
                         stub(OK, buildBody(response), mappingBuilder);
             }
@@ -59,7 +59,7 @@ public class JavaGetRestControllerStub {
                     
                                                 mappingBuilder.withQueryParam("param", equalTo(serialise(param, "java.time.ZonedDateTime", "DATE_TIME", "", "SS", "")));
                             
-                                                mappingBuilder.withQueryParam("multiValue", havingExactly(multiValue.stream().map(x -> x.toString()).toArray(String[]::new)));
+                                                            mappingBuilder.withQueryParam("multiValue", havingExactly(multiValue.stream().map(x -> x.toString()).toArray(String[]::new)));
             
                         stub(httpStatus, response, mappingBuilder);
             }
@@ -71,19 +71,19 @@ public class JavaGetRestControllerStub {
     public void verifyResourceWithZonedDatetimeAndMultiValue(final int times, java.time.ZonedDateTime param, java.util.Set<java.lang.Integer> multiValue) {
         String url = String.format(RESOURCEWITHZONEDDATETIMEANDMULTIVALUE_URL);
         RequestPatternBuilder requestPatternBuilder = getRequestedFor(urlPathEqualTo(url));
-                                                                requestPatternBuilder.withQueryParam("param", equalTo(serialise(param, "java.time.ZonedDateTime", "DATE_TIME", "", "SS", "")));
+                                                    requestPatternBuilder.withQueryParam("param", equalTo(serialise(param, "java.time.ZonedDateTime", "DATE_TIME", "", "SS", "")));
                                                                         requestPatternBuilder.withQueryParam("multiValue", havingExactly(multiValue.stream().map(x -> x.toString()).toArray(String[]::new)));
-                                                                        verify(times, requestPatternBuilder);
-            }
+                                                            verify(times, requestPatternBuilder);
+    }
 
     
     public void verifyResourceWithZonedDatetimeAndMultiValueNoInteraction(java.time.ZonedDateTime param, java.util.Set<java.lang.Integer> multiValue) {
         String url = String.format(RESOURCEWITHZONEDDATETIMEANDMULTIVALUE_URL);
         RequestPatternBuilder requestPatternBuilder = getRequestedFor(urlPathEqualTo(url));
-                                                                requestPatternBuilder.withQueryParam("param", equalTo(serialise(param, "java.time.ZonedDateTime", "DATE_TIME", "", "SS", "")));
+                                                    requestPatternBuilder.withQueryParam("param", equalTo(serialise(param, "java.time.ZonedDateTime", "DATE_TIME", "", "SS", "")));
                                                                         requestPatternBuilder.withQueryParam("multiValue", havingExactly(multiValue.stream().map(x -> x.toString()).toArray(String[]::new)));
-                                                                        verify(NEVER, requestPatternBuilder);
-            }
+                                                            verify(NEVER, requestPatternBuilder);
+    }
 
         public void verifyResourceWithZonedDatetimeAndMultiValueNoInteraction() {
         String url = String.format(RESOURCEWITHZONEDDATETIMEANDMULTIVALUE_URL);
@@ -117,17 +117,17 @@ public class JavaGetRestControllerStub {
     public void verifyResourceWithParamAndAnnotations(final int times, java.lang.String param) {
         String url = String.format(RESOURCEWITHPARAMANDANNOTATIONS_URL);
         RequestPatternBuilder requestPatternBuilder = getRequestedFor(urlPathEqualTo(url));
-                                                                requestPatternBuilder.withQueryParam("param", equalTo(String.valueOf(param)));
-                                                                        verify(times, requestPatternBuilder);
-            }
+                                                    requestPatternBuilder.withQueryParam("param", equalTo(String.valueOf(param)));
+                                                            verify(times, requestPatternBuilder);
+    }
 
     
     public void verifyResourceWithParamAndAnnotationsNoInteraction(java.lang.String param) {
         String url = String.format(RESOURCEWITHPARAMANDANNOTATIONS_URL);
         RequestPatternBuilder requestPatternBuilder = getRequestedFor(urlPathEqualTo(url));
-                                                                requestPatternBuilder.withQueryParam("param", equalTo(String.valueOf(param)));
-                                                                        verify(NEVER, requestPatternBuilder);
-            }
+                                                    requestPatternBuilder.withQueryParam("param", equalTo(String.valueOf(param)));
+                                                            verify(NEVER, requestPatternBuilder);
+    }
 
         public void verifyResourceWithParamAndAnnotationsNoInteraction() {
         String url = String.format(RESOURCEWITHPARAMANDANNOTATIONS_URL);

--- a/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/get/JavaGetRestControllerIT.should remove unwanted annotations from any arguments.approved
+++ b/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/get/JavaGetRestControllerIT.should remove unwanted annotations from any arguments.approved
@@ -8,6 +8,7 @@ import javax.annotation.processing.Generated;
 import org.springframework.format.AnnotationFormatterFactory;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.format.Printer;
+import java.util.List;
 import java.util.Locale;
 import java.lang.annotation.Annotation;
 
@@ -195,6 +196,15 @@ public class JavaGetRestControllerStub {
         } catch(ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public String joinWithFirstSeparator(String firstSep, String sep, List<String> strings) {
+        if (strings.isEmpty()) return "";
+        StringBuilder sb = new StringBuilder(strings.get(0));
+        for (int i = 1; i < strings.size(); i++) {
+            sb.append(i == 1 ? firstSep : sep).append(strings.get(i));
+        }
+        return sb.toString();
     }
 }
 

--- a/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/get/JavaGetRestControllerIT.should remove unwanted annotations from any arguments.approved
+++ b/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/get/JavaGetRestControllerIT.should remove unwanted annotations from any arguments.approved
@@ -79,8 +79,7 @@ public class JavaGetRestControllerStub {
         String url = String.format(RESOURCEWITHZONEDDATETIMEANDMULTIVALUE_URL);
         RequestPatternBuilder requestPatternBuilder = getRequestedFor(urlPathEqualTo(url));
                                                                 requestPatternBuilder.withQueryParam("param", equalTo(serialise(param, "java.time.ZonedDateTime", "DATE_TIME", "", "SS", "")));
-                                                            url = url + "multiValue=";
-                        requestPatternBuilder.withQueryParam("multiValue", havingExactly(multiValue.stream().map(x -> x.toString()).toArray(String[]::new)));
+                                                                        requestPatternBuilder.withQueryParam("multiValue", havingExactly(multiValue.stream().map(x -> x.toString()).toArray(String[]::new)));
                                             verify(times, requestPatternBuilder
                             );
             }
@@ -90,8 +89,7 @@ public class JavaGetRestControllerStub {
         String url = String.format(RESOURCEWITHZONEDDATETIMEANDMULTIVALUE_URL);
         RequestPatternBuilder requestPatternBuilder = getRequestedFor(urlPathEqualTo(url));
                                                                 requestPatternBuilder.withQueryParam("param", equalTo(serialise(param, "java.time.ZonedDateTime", "DATE_TIME", "", "SS", "")));
-                                                            url = url + "multiValue=";
-                        requestPatternBuilder.withQueryParam("multiValue", havingExactly(multiValue.stream().map(x -> x.toString()).toArray(String[]::new)));
+                                                                        requestPatternBuilder.withQueryParam("multiValue", havingExactly(multiValue.stream().map(x -> x.toString()).toArray(String[]::new)));
                                             verify(NEVER, requestPatternBuilder
                             );
             }

--- a/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/get/JavaGetRestControllerIT.should remove unwanted annotations from any arguments.approved
+++ b/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/get/JavaGetRestControllerIT.should remove unwanted annotations from any arguments.approved
@@ -77,32 +77,30 @@ public class JavaGetRestControllerStub {
 
     public void verifyResourceWithZonedDatetimeAndMultiValue(final int times, java.time.ZonedDateTime param, java.util.Set<java.lang.Integer> multiValue) {
         String url = String.format(RESOURCEWITHZONEDDATETIMEANDMULTIVALUE_URL);
+        RequestPatternBuilder requestedFor = getRequestedFor(urlPathEqualTo(url));
                         if (param != null) {
-                    url = url + "?";
-                                            url = url + "param=" + serialise(param, "java.time.ZonedDateTime", "DATE_TIME", "", "SS", "");
+                                requestedFor.withQueryParam("param", equalTo(serialise(param, "java.time.ZonedDateTime", "DATE_TIME", "", "SS", "")));
                     }
     if (multiValue != null) {
-                    url = url + "&";
-                            url = url + "multiValue=";
-                            url = url + String.join("&multiValue=", multiValue.stream().map(x -> x.toString()).collect(toList()));
+                    url = url + "multiValue=";
+                        requestedFor.withQueryParam("multiValue", havingExactly(multiValue.stream().map(x -> x.toString()).toArray(String[]::new)));
                     }
-                verify(times, getRequestedFor(urlEqualTo(url))
+                verify(times, requestedFor
                             );
             }
 
     
     public void verifyResourceWithZonedDatetimeAndMultiValueNoInteraction(java.time.ZonedDateTime param, java.util.Set<java.lang.Integer> multiValue) {
         String url = String.format(RESOURCEWITHZONEDDATETIMEANDMULTIVALUE_URL);
+        RequestPatternBuilder requestedFor = getRequestedFor(urlPathEqualTo(url));
                         if (param != null) {
-                    url = url + "?";
-                                            url = url + "param=" + serialise(param, "java.time.ZonedDateTime", "DATE_TIME", "", "SS", "");
+                                requestedFor.withQueryParam("param", equalTo(serialise(param, "java.time.ZonedDateTime", "DATE_TIME", "", "SS", "")));
                     }
     if (multiValue != null) {
-                    url = url + "&";
-                            url = url + "multiValue=";
-                            url = url + String.join("&multiValue=", multiValue.stream().map(x -> x.toString()).collect(toList()));
+                    url = url + "multiValue=";
+                        requestedFor.withQueryParam("multiValue", havingExactly(multiValue.stream().map(x -> x.toString()).toArray(String[]::new)));
                     }
-                verify(NEVER, getRequestedFor(urlEqualTo(url))
+                verify(NEVER, requestedFor
                             );
             }
 
@@ -129,6 +127,7 @@ public class JavaGetRestControllerStub {
 
     public void verifyResourceWithParamAndAnnotations(final int times, java.lang.String param) {
         String url = String.format(RESOURCEWITHPARAMANDANNOTATIONS_URL);
+        RequestPatternBuilder requestedFor = getRequestedFor(urlPathEqualTo(url));
                     RequestPatternBuilder requestPatternBuilder = getRequestedFor(urlPathEqualTo(format(url)));
                                             requestPatternBuilder.withQueryParam("param", equalTo(String.valueOf(param)));
                                                             verify(times, requestPatternBuilder);
@@ -137,6 +136,7 @@ public class JavaGetRestControllerStub {
     
     public void verifyResourceWithParamAndAnnotationsNoInteraction(java.lang.String param) {
         String url = String.format(RESOURCEWITHPARAMANDANNOTATIONS_URL);
+        RequestPatternBuilder requestedFor = getRequestedFor(urlPathEqualTo(url));
                     RequestPatternBuilder requestPatternBuilder = getRequestedFor(urlPathEqualTo(format(url)));
                                             requestPatternBuilder.withQueryParam("param", equalTo(String.valueOf(param)));
                                                             verify(NEVER, requestPatternBuilder);
@@ -210,6 +210,7 @@ public class JavaGetRestControllerStub {
         }
     }
 }
+
 
 
 

--- a/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/post/JavaPostRestControllerIT.should remove unwanted annotations from any arguments.approved
+++ b/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/post/JavaPostRestControllerIT.should remove unwanted annotations from any arguments.approved
@@ -5,6 +5,7 @@ import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
 import static java.lang.String.format;
 import javax.annotation.processing.Generated;
+import java.util.List;
 import java.util.Locale;
 import java.lang.annotation.Annotation;
 

--- a/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/post/JavaPostRestControllerIT.should remove unwanted annotations from any arguments.approved
+++ b/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/post/JavaPostRestControllerIT.should remove unwanted annotations from any arguments.approved
@@ -57,24 +57,21 @@ public class JavaPostRestControllerStub {
 
     public void verifyResourceWithBodyAndAnnotations(final int times, com.lsdconsulting.stub.integration.model.GreetingRequest greetingRequest) {
         String url = String.format(RESOURCEWITHBODYANDANNOTATIONS_URL);
-        RequestPatternBuilder requestedFor = postRequestedFor(urlPathEqualTo(url));
-                    RequestPatternBuilder requestPatternBuilder = postRequestedFor(urlPathEqualTo(format(url)));
-                                                            requestPatternBuilder.withRequestBody(equalToJson(buildBody(greetingRequest)));
+        RequestPatternBuilder requestPatternBuilder = postRequestedFor(urlPathEqualTo(url));
+                                                                    requestPatternBuilder.withRequestBody(equalToJson(buildBody(greetingRequest)));
                         verify(times, requestPatternBuilder);
             }
 
         public void verifyResourceWithBodyAndAnnotations(final int times) {
         String url = String.format(RESOURCEWITHBODYANDANNOTATIONS_URL);
-        RequestPatternBuilder requestedFor = postRequestedFor(urlPathEqualTo(url));
-                    RequestPatternBuilder requestPatternBuilder = postRequestedFor(urlPathEqualTo(format(url)));
-                                            verify(times, requestPatternBuilder);
+        RequestPatternBuilder requestPatternBuilder = postRequestedFor(urlPathEqualTo(url));
+                                                    verify(times, requestPatternBuilder);
             }
     
     public void verifyResourceWithBodyAndAnnotationsNoInteraction(com.lsdconsulting.stub.integration.model.GreetingRequest greetingRequest) {
         String url = String.format(RESOURCEWITHBODYANDANNOTATIONS_URL);
-        RequestPatternBuilder requestedFor = postRequestedFor(urlPathEqualTo(url));
-                    RequestPatternBuilder requestPatternBuilder = postRequestedFor(urlPathEqualTo(format(url)));
-                                                            requestPatternBuilder.withRequestBody(equalToJson(buildBody(greetingRequest)));
+        RequestPatternBuilder requestPatternBuilder = postRequestedFor(urlPathEqualTo(url));
+                                                                    requestPatternBuilder.withRequestBody(equalToJson(buildBody(greetingRequest)));
                         verify(NEVER, requestPatternBuilder);
             }
 
@@ -108,24 +105,21 @@ public class JavaPostRestControllerStub {
 
     public void verifyResourceWithBodyAndAnnotationsOnPathVariables(final int times, java.lang.String param, com.lsdconsulting.stub.integration.model.GreetingRequest greetingRequest) {
         String url = String.format(RESOURCEWITHBODYANDANNOTATIONSONPATHVARIABLES_URL, param );
-        RequestPatternBuilder requestedFor = postRequestedFor(urlPathEqualTo(url));
-                    RequestPatternBuilder requestPatternBuilder = postRequestedFor(urlPathEqualTo(format(url)));
-                                                            requestPatternBuilder.withRequestBody(equalToJson(buildBody(greetingRequest)));
+        RequestPatternBuilder requestPatternBuilder = postRequestedFor(urlPathEqualTo(url));
+                                                                    requestPatternBuilder.withRequestBody(equalToJson(buildBody(greetingRequest)));
                         verify(times, requestPatternBuilder);
             }
 
         public void verifyResourceWithBodyAndAnnotationsOnPathVariables(final int times, java.lang.String param) {
         String url = String.format(RESOURCEWITHBODYANDANNOTATIONSONPATHVARIABLES_URL, param );
-        RequestPatternBuilder requestedFor = postRequestedFor(urlPathEqualTo(url));
-                    RequestPatternBuilder requestPatternBuilder = postRequestedFor(urlPathEqualTo(format(url)));
-                                            verify(times, requestPatternBuilder);
+        RequestPatternBuilder requestPatternBuilder = postRequestedFor(urlPathEqualTo(url));
+                                                    verify(times, requestPatternBuilder);
             }
     
     public void verifyResourceWithBodyAndAnnotationsOnPathVariablesNoInteraction(java.lang.String param, com.lsdconsulting.stub.integration.model.GreetingRequest greetingRequest) {
         String url = String.format(RESOURCEWITHBODYANDANNOTATIONSONPATHVARIABLES_URL, param );
-        RequestPatternBuilder requestedFor = postRequestedFor(urlPathEqualTo(url));
-                    RequestPatternBuilder requestPatternBuilder = postRequestedFor(urlPathEqualTo(format(url)));
-                                                            requestPatternBuilder.withRequestBody(equalToJson(buildBody(greetingRequest)));
+        RequestPatternBuilder requestPatternBuilder = postRequestedFor(urlPathEqualTo(url));
+                                                                    requestPatternBuilder.withRequestBody(equalToJson(buildBody(greetingRequest)));
                         verify(NEVER, requestPatternBuilder);
             }
 
@@ -154,7 +148,6 @@ public class JavaPostRestControllerStub {
     }
 
 }
-
 
 
 

--- a/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/post/JavaPostRestControllerIT.should remove unwanted annotations from any arguments.approved
+++ b/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/post/JavaPostRestControllerIT.should remove unwanted annotations from any arguments.approved
@@ -57,6 +57,7 @@ public class JavaPostRestControllerStub {
 
     public void verifyResourceWithBodyAndAnnotations(final int times, com.lsdconsulting.stub.integration.model.GreetingRequest greetingRequest) {
         String url = String.format(RESOURCEWITHBODYANDANNOTATIONS_URL);
+        RequestPatternBuilder requestedFor = postRequestedFor(urlPathEqualTo(url));
                     RequestPatternBuilder requestPatternBuilder = postRequestedFor(urlPathEqualTo(format(url)));
                                                             requestPatternBuilder.withRequestBody(equalToJson(buildBody(greetingRequest)));
                         verify(times, requestPatternBuilder);
@@ -64,12 +65,14 @@ public class JavaPostRestControllerStub {
 
         public void verifyResourceWithBodyAndAnnotations(final int times) {
         String url = String.format(RESOURCEWITHBODYANDANNOTATIONS_URL);
+        RequestPatternBuilder requestedFor = postRequestedFor(urlPathEqualTo(url));
                     RequestPatternBuilder requestPatternBuilder = postRequestedFor(urlPathEqualTo(format(url)));
                                             verify(times, requestPatternBuilder);
             }
     
     public void verifyResourceWithBodyAndAnnotationsNoInteraction(com.lsdconsulting.stub.integration.model.GreetingRequest greetingRequest) {
         String url = String.format(RESOURCEWITHBODYANDANNOTATIONS_URL);
+        RequestPatternBuilder requestedFor = postRequestedFor(urlPathEqualTo(url));
                     RequestPatternBuilder requestPatternBuilder = postRequestedFor(urlPathEqualTo(format(url)));
                                                             requestPatternBuilder.withRequestBody(equalToJson(buildBody(greetingRequest)));
                         verify(NEVER, requestPatternBuilder);
@@ -105,6 +108,7 @@ public class JavaPostRestControllerStub {
 
     public void verifyResourceWithBodyAndAnnotationsOnPathVariables(final int times, java.lang.String param, com.lsdconsulting.stub.integration.model.GreetingRequest greetingRequest) {
         String url = String.format(RESOURCEWITHBODYANDANNOTATIONSONPATHVARIABLES_URL, param );
+        RequestPatternBuilder requestedFor = postRequestedFor(urlPathEqualTo(url));
                     RequestPatternBuilder requestPatternBuilder = postRequestedFor(urlPathEqualTo(format(url)));
                                                             requestPatternBuilder.withRequestBody(equalToJson(buildBody(greetingRequest)));
                         verify(times, requestPatternBuilder);
@@ -112,12 +116,14 @@ public class JavaPostRestControllerStub {
 
         public void verifyResourceWithBodyAndAnnotationsOnPathVariables(final int times, java.lang.String param) {
         String url = String.format(RESOURCEWITHBODYANDANNOTATIONSONPATHVARIABLES_URL, param );
+        RequestPatternBuilder requestedFor = postRequestedFor(urlPathEqualTo(url));
                     RequestPatternBuilder requestPatternBuilder = postRequestedFor(urlPathEqualTo(format(url)));
                                             verify(times, requestPatternBuilder);
             }
     
     public void verifyResourceWithBodyAndAnnotationsOnPathVariablesNoInteraction(java.lang.String param, com.lsdconsulting.stub.integration.model.GreetingRequest greetingRequest) {
         String url = String.format(RESOURCEWITHBODYANDANNOTATIONSONPATHVARIABLES_URL, param );
+        RequestPatternBuilder requestedFor = postRequestedFor(urlPathEqualTo(url));
                     RequestPatternBuilder requestPatternBuilder = postRequestedFor(urlPathEqualTo(format(url)));
                                                             requestPatternBuilder.withRequestBody(equalToJson(buildBody(greetingRequest)));
                         verify(NEVER, requestPatternBuilder);
@@ -148,6 +154,7 @@ public class JavaPostRestControllerStub {
     }
 
 }
+
 
 
 

--- a/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/post/JavaPostRestControllerIT.should remove unwanted annotations from any arguments.approved
+++ b/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/post/JavaPostRestControllerIT.should remove unwanted annotations from any arguments.approved
@@ -58,22 +58,22 @@ public class JavaPostRestControllerStub {
     public void verifyResourceWithBodyAndAnnotations(final int times, com.lsdconsulting.stub.integration.model.GreetingRequest greetingRequest) {
         String url = String.format(RESOURCEWITHBODYANDANNOTATIONS_URL);
         RequestPatternBuilder requestPatternBuilder = postRequestedFor(urlPathEqualTo(url));
-                                                                    requestPatternBuilder.withRequestBody(equalToJson(buildBody(greetingRequest)));
-                        verify(times, requestPatternBuilder);
-            }
+                                            requestPatternBuilder.withRequestBody(equalToJson(buildBody(greetingRequest)));
+                verify(times, requestPatternBuilder);
+    }
 
         public void verifyResourceWithBodyAndAnnotations(final int times) {
         String url = String.format(RESOURCEWITHBODYANDANNOTATIONS_URL);
         RequestPatternBuilder requestPatternBuilder = postRequestedFor(urlPathEqualTo(url));
-                                                    verify(times, requestPatternBuilder);
-            }
+                                verify(times, requestPatternBuilder);
+    }
     
     public void verifyResourceWithBodyAndAnnotationsNoInteraction(com.lsdconsulting.stub.integration.model.GreetingRequest greetingRequest) {
         String url = String.format(RESOURCEWITHBODYANDANNOTATIONS_URL);
         RequestPatternBuilder requestPatternBuilder = postRequestedFor(urlPathEqualTo(url));
-                                                                    requestPatternBuilder.withRequestBody(equalToJson(buildBody(greetingRequest)));
-                        verify(NEVER, requestPatternBuilder);
-            }
+                                            requestPatternBuilder.withRequestBody(equalToJson(buildBody(greetingRequest)));
+                verify(NEVER, requestPatternBuilder);
+    }
 
         public void verifyResourceWithBodyAndAnnotationsNoInteraction() {
         String url = String.format(RESOURCEWITHBODYANDANNOTATIONS_URL);
@@ -106,22 +106,22 @@ public class JavaPostRestControllerStub {
     public void verifyResourceWithBodyAndAnnotationsOnPathVariables(final int times, java.lang.String param, com.lsdconsulting.stub.integration.model.GreetingRequest greetingRequest) {
         String url = String.format(RESOURCEWITHBODYANDANNOTATIONSONPATHVARIABLES_URL, param );
         RequestPatternBuilder requestPatternBuilder = postRequestedFor(urlPathEqualTo(url));
-                                                                    requestPatternBuilder.withRequestBody(equalToJson(buildBody(greetingRequest)));
-                        verify(times, requestPatternBuilder);
-            }
+                                            requestPatternBuilder.withRequestBody(equalToJson(buildBody(greetingRequest)));
+                verify(times, requestPatternBuilder);
+    }
 
         public void verifyResourceWithBodyAndAnnotationsOnPathVariables(final int times, java.lang.String param) {
         String url = String.format(RESOURCEWITHBODYANDANNOTATIONSONPATHVARIABLES_URL, param );
         RequestPatternBuilder requestPatternBuilder = postRequestedFor(urlPathEqualTo(url));
-                                                    verify(times, requestPatternBuilder);
-            }
+                                verify(times, requestPatternBuilder);
+    }
     
     public void verifyResourceWithBodyAndAnnotationsOnPathVariablesNoInteraction(java.lang.String param, com.lsdconsulting.stub.integration.model.GreetingRequest greetingRequest) {
         String url = String.format(RESOURCEWITHBODYANDANNOTATIONSONPATHVARIABLES_URL, param );
         RequestPatternBuilder requestPatternBuilder = postRequestedFor(urlPathEqualTo(url));
-                                                                    requestPatternBuilder.withRequestBody(equalToJson(buildBody(greetingRequest)));
-                        verify(NEVER, requestPatternBuilder);
-            }
+                                            requestPatternBuilder.withRequestBody(equalToJson(buildBody(greetingRequest)));
+                verify(NEVER, requestPatternBuilder);
+    }
 
         public void verifyResourceWithBodyAndAnnotationsOnPathVariablesNoInteraction(java.lang.String param) {
         String url = String.format(RESOURCEWITHBODYANDANNOTATIONSONPATHVARIABLES_URL, param );

--- a/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/post/JavaPostRestControllerIT.should remove unwanted annotations from any arguments.approved
+++ b/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/post/JavaPostRestControllerIT.should remove unwanted annotations from any arguments.approved
@@ -35,14 +35,14 @@ public class JavaPostRestControllerStub {
 
     public void resourceWithBodyAndAnnotations(com.lsdconsulting.stub.integration.model.GreetingResponse response) {
         String url = String.format(RESOURCEWITHBODYANDANNOTATIONS_URL);
-        MappingBuilder mappingBuilder = post(urlPathEqualTo(url));
-                                    stub(OK, buildBody(response), mappingBuilder);
+                    MappingBuilder mappingBuilder = post(urlPathEqualTo(url));
+                            stub(OK, buildBody(response), mappingBuilder);
             }
 
         public void resourceWithBodyAndAnnotations(com.lsdconsulting.stub.integration.model.GreetingRequest greetingRequest, com.lsdconsulting.stub.integration.model.GreetingResponse response) {
         String url = String.format(RESOURCEWITHBODYANDANNOTATIONS_URL);
-        MappingBuilder mappingBuilder = post(urlPathEqualTo(url)).withRequestBody(equalToJson(buildBody(greetingRequest)));
-                                    stub(OK, buildBody(response), mappingBuilder);
+                    MappingBuilder mappingBuilder = post(urlPathEqualTo(url)).withRequestBody(equalToJson(buildBody(greetingRequest)));
+                            stub(OK, buildBody(response), mappingBuilder);
             }
     
     public void resourceWithBodyAndAnnotations(int httpStatus, String response) {
@@ -83,14 +83,14 @@ public class JavaPostRestControllerStub {
 
     public void resourceWithBodyAndAnnotationsOnPathVariables(com.lsdconsulting.stub.integration.model.GreetingResponse response, java.lang.String param) {
         String url = String.format(RESOURCEWITHBODYANDANNOTATIONSONPATHVARIABLES_URL, param );
-        MappingBuilder mappingBuilder = post(urlPathEqualTo(url));
-                                    stub(OK, buildBody(response), mappingBuilder);
+                    MappingBuilder mappingBuilder = post(urlPathEqualTo(url));
+                            stub(OK, buildBody(response), mappingBuilder);
             }
 
         public void resourceWithBodyAndAnnotationsOnPathVariables(com.lsdconsulting.stub.integration.model.GreetingRequest greetingRequest, com.lsdconsulting.stub.integration.model.GreetingResponse response, java.lang.String param) {
         String url = String.format(RESOURCEWITHBODYANDANNOTATIONSONPATHVARIABLES_URL, param );
-        MappingBuilder mappingBuilder = post(urlPathEqualTo(url)).withRequestBody(equalToJson(buildBody(greetingRequest)));
-                                    stub(OK, buildBody(response), mappingBuilder);
+                    MappingBuilder mappingBuilder = post(urlPathEqualTo(url)).withRequestBody(equalToJson(buildBody(greetingRequest)));
+                            stub(OK, buildBody(response), mappingBuilder);
             }
     
     public void resourceWithBodyAndAnnotationsOnPathVariables(int httpStatus, String response, java.lang.String param) {

--- a/generator/src/main/kotlin/io/lsdconsulting/stub/model/ControllerModel.kt
+++ b/generator/src/main/kotlin/io/lsdconsulting/stub/model/ControllerModel.kt
@@ -27,7 +27,7 @@ data class ResourceModel(
     var responseStatus: Int? = null,
     var subResource: String? = null,
     var urlHasPathVariable: Boolean = false,
-    var hasMultiValueRequestParams: Boolean = false,
+    var hasOptionalMultiValueRequestParams: Boolean = false,
     val requestParameters: MutableMap<String, ArgumentModel> = mutableMapOf(),
     val pathVariables: MutableMap<String, ArgumentModel> = mutableMapOf(),
     var requestBody: ArgumentModel? = null,

--- a/generator/src/main/kotlin/io/lsdconsulting/stub/processor/ControllerProcessor.kt
+++ b/generator/src/main/kotlin/io/lsdconsulting/stub/processor/ControllerProcessor.kt
@@ -149,7 +149,9 @@ class ControllerProcessor : AbstractProcessor() {
                         controllerModel.getResourceModel(methodName).getRequestParamModel(argumentName).optional = !requestParam.required
 
                         if ("java.util.Set<(.*)>|java.util.List<(.*)>|java.lang.String\\[]".toRegex().containsMatchIn(argumentType)) {
-                            controllerModel.getResourceModel(methodName).hasMultiValueRequestParams = true
+                            if (!controllerModel.getResourceModel(methodName).hasOptionalMultiValueRequestParams) { // So that other non-optional multi value query parameters don't overwrite this value
+                                controllerModel.getResourceModel(methodName).hasOptionalMultiValueRequestParams = !requestParam.required
+                            }
                             controllerModel.getResourceModel(methodName).getRequestParamModel(argumentName).iterable = true
                         }
                     }

--- a/generator/src/main/resources/templates/Stub.peb
+++ b/generator/src/main/resources/templates/Stub.peb
@@ -10,6 +10,7 @@ import org.springframework.format.AnnotationFormatterFactory;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.format.Printer;
 {% endif %}
+import java.util.List;
 import java.util.Locale;
 import java.lang.annotation.Annotation;
 
@@ -195,6 +196,15 @@ public class {{model.stubClassName}} {
             throw new RuntimeException(e);
         }
     }
+
+    public String joinWithFirstSeparator(String firstSep, String sep, List<String> strings) {
+        if (strings.isEmpty()) return "";
+        StringBuilder sb = new StringBuilder(strings.get(0));
+        for (int i = 1; i < strings.size(); i++) {
+            sb.append(i == 1 ? firstSep : sep).append(strings.get(i));
+        }
+        return sb.toString();
+    }
 {% endif %}
 }
 {% macro generateUrlWithPathVariables(entry) %}
@@ -208,17 +218,21 @@ String url = String.format({{entry.value.methodName.toUpperCase()}}_URL{% for en
 {% macro addRequestParamsToUrl(entry) %}
     {% for entry2 in entry.value.requestParameters %}
 if ({{entry2.value.name}} != null) {
-        {% if loop.first %}
-            url = url + "?";
-        {% else %}
-            url = url + "&";
-        {% endif %}
+        if (!url.contains("?")) { url = url + "?"; } else { url = url + "&"; }
         {% if entry2.value.iterable %}
             url = url + "{{entry2.value.name}}=";
             {% if entry2.value.dateTimeFormatAnnotation is not empty %}
-                url = url + String.join("&{{entry2.value.name}}=", {{entry2.value.name}}.stream().map(x -> serialise(x, "{{entry2.value.dateTimeFormatAnnotation.clazz}}", "{{entry2.value.dateTimeFormatAnnotation.iso}}", "{{entry2.value.dateTimeFormatAnnotation.pattern | raw}}", "{{entry2.value.dateTimeFormatAnnotation.style}}", "{{entry2.value.dateTimeFormatAnnotation.fallbackPatterns | join('","') | raw}}")).collect(toList()));
+                if (!url.contains("?")) {
+                    url = url + joinWithFirstSeparator("?{{entry2.value.name}}=", "&{{entry2.value.name}}=", {{entry2.value.name}}.stream().map(x -> serialise(x, "{{entry2.value.dateTimeFormatAnnotation.clazz}}", "{{entry2.value.dateTimeFormatAnnotation.iso}}", "{{entry2.value.dateTimeFormatAnnotation.pattern | raw}}", "{{entry2.value.dateTimeFormatAnnotation.style}}", "{{entry2.value.dateTimeFormatAnnotation.fallbackPatterns | join('","') | raw}}")).collect(toList()));
+                } else {
+                    url = url + String.join("&{{entry2.value.name}}=", {{entry2.value.name}}.stream().map(x -> serialise(x, "{{entry2.value.dateTimeFormatAnnotation.clazz}}", "{{entry2.value.dateTimeFormatAnnotation.iso}}", "{{entry2.value.dateTimeFormatAnnotation.pattern | raw}}", "{{entry2.value.dateTimeFormatAnnotation.style}}", "{{entry2.value.dateTimeFormatAnnotation.fallbackPatterns | join('","') | raw}}")).collect(toList()));
+                }
             {% else %}
-                url = url + String.join("&{{entry2.value.name}}=", {{entry2.value.name}}.stream().map(x -> x.toString()).collect(toList()));
+                if (!url.contains("?")) {
+                    url = url + joinWithFirstSeparator("?{{entry2.value.name}}=", "&{{entry2.value.name}}=", {{entry2.value.name}}.stream().map(x -> x.toString()).collect(toList()));
+                } else {
+                    url = url + String.join("&{{entry2.value.name}}=", {{entry2.value.name}}.stream().map(x -> x.toString()).collect(toList()));
+                }
             {% endif %}
         {% else %}
             {% if entry2.value.dateTimeFormatAnnotation is not empty %}

--- a/generator/src/main/resources/templates/Stub.peb
+++ b/generator/src/main/resources/templates/Stub.peb
@@ -92,10 +92,10 @@ public class {{model.stubClassName}} {
 
     public void verify{{entry.value.methodName}}({{ entry.value.verifyMethodArgumentListWithTimes | join(', ') | raw}}) {
         {{ generateUrlWithPathVariables(entry) }}
-        RequestPatternBuilder requestedFor = {{entry.value.httpMethod.name() | lower}}RequestedFor(urlPathEqualTo(url));
+        RequestPatternBuilder requestPatternBuilder = {{entry.value.httpMethod.name() | lower}}RequestedFor(urlPathEqualTo(url));
         {% if entry.value.hasMultiValueRequestParams %}
             {{ addRequestParamsToPatternBuilder(entry) }}
-            verify(times, requestedFor
+            verify(times, requestPatternBuilder
                 {% if entry.value.requestBody is not empty%}
                 .withRequestBody(equalToJson(buildBody({{ entry.value.requestBody.name }})))
                 {% endif %}
@@ -114,10 +114,10 @@ public class {{model.stubClassName}} {
     {% if entry.value.verifyMethodArgumentListWithTimesWithoutBody != entry.value.verifyMethodArgumentListWithTimes %}
     public void verify{{entry.value.methodName}}({{ entry.value.verifyMethodArgumentListWithTimesWithoutBody | join(', ') | raw}}) {
         {{ generateUrlWithPathVariables(entry) }}
-        RequestPatternBuilder requestedFor = {{entry.value.httpMethod.name() | lower}}RequestedFor(urlPathEqualTo(url));
+        RequestPatternBuilder requestPatternBuilder = {{entry.value.httpMethod.name() | lower}}RequestedFor(urlPathEqualTo(url));
         {% if entry.value.hasMultiValueRequestParams %}
             {{ addRequestParamsToPatternBuilder(entry) }}
-            verify(times, requestedFor);
+            verify(times, requestPatternBuilder);
         {% else %}
             RequestPatternBuilder requestPatternBuilder = {{entry.value.httpMethod.name() | lower}}RequestedFor(urlPathEqualTo(format(url)));
             {{ addQueryParamsToRequestPatternBuilder(entry) }}
@@ -129,10 +129,10 @@ public class {{model.stubClassName}} {
 
     public void verify{{entry.value.methodName}}NoInteraction({{ entry.value.verifyMethodArgumentList | join(', ') | raw}}) {
         {{ generateUrlWithPathVariables(entry) }}
-        RequestPatternBuilder requestedFor = {{entry.value.httpMethod.name() | lower}}RequestedFor(urlPathEqualTo(url));
+        RequestPatternBuilder requestPatternBuilder = {{entry.value.httpMethod.name() | lower}}RequestedFor(urlPathEqualTo(url));
         {% if entry.value.hasMultiValueRequestParams %}
             {{ addRequestParamsToPatternBuilder(entry) }}
-            verify(NEVER, requestedFor
+            verify(NEVER, requestPatternBuilder
                 {% if entry.value.requestBody is not empty%}
                 .withRequestBody(equalToJson(buildBody({{ entry.value.requestBody.name }})))
                 {% endif %}
@@ -255,31 +255,6 @@ if ({{entry2.value.name}} != null) {
     {% endfor %}
 {% endmacro %}
 
-{% macro addRequestParamsToPatternBuilder(entry) %}
-    {% for entry2 in entry.value.requestParameters %}
-if ({{entry2.value.name}} != null) {
-        {% if entry2.value.iterable %}
-            url = url + "{{entry2.value.name}}=";
-            {% if entry2.value.dateTimeFormatAnnotation is not empty %}
-            requestedFor.withQueryParam("{{entry2.value.name}}", havingExactly({{entry2.value.name}}.stream().map(x -> serialise(x, "{{entry2.value.dateTimeFormatAnnotation.clazz}}", "{{entry2.value.dateTimeFormatAnnotation.iso}}", "{{entry2.value.dateTimeFormatAnnotation.pattern | raw}}", "{{entry2.value.dateTimeFormatAnnotation.style}}", "{{entry2.value.dateTimeFormatAnnotation.fallbackPatterns | join('","') | raw}}")).toArray(String[]::new)));
-{#                url = url + String.join("&{{entry2.value.name}}=", {{entry2.value.name}}.stream().map(x -> serialise(x, "{{entry2.value.dateTimeFormatAnnotation.clazz}}", "{{entry2.value.dateTimeFormatAnnotation.iso}}", "{{entry2.value.dateTimeFormatAnnotation.pattern | raw}}", "{{entry2.value.dateTimeFormatAnnotation.style}}", "{{entry2.value.dateTimeFormatAnnotation.fallbackPatterns | join('","') | raw}}")).collect(toList()));#}
-            {% else %}
-            requestedFor.withQueryParam("{{entry2.value.name}}", havingExactly({{entry2.value.name}}.stream().map(x -> x.toString()).toArray(String[]::new)));
-{#                url = url + String.join("&{{entry2.value.name}}=", {{entry2.value.name}}.stream().map(x -> x.toString()).collect(toList()));#}
-            {% endif %}
-        {% else %}
-            {% if entry2.value.dateTimeFormatAnnotation is not empty %}
-            requestedFor.withQueryParam("{{entry2.value.name}}", equalTo(serialise({{entry2.value.name}}, "{{entry2.value.dateTimeFormatAnnotation.clazz}}", "{{entry2.value.dateTimeFormatAnnotation.iso}}", "{{entry2.value.dateTimeFormatAnnotation.pattern | raw}}", "{{entry2.value.dateTimeFormatAnnotation.style}}", "{{entry2.value.dateTimeFormatAnnotation.fallbackPatterns | join('","') | raw}}")));
-{#                url = url + "{{entry2.value.name}}=" + serialise({{entry2.value.name}}, "{{entry2.value.dateTimeFormatAnnotation.clazz}}", "{{entry2.value.dateTimeFormatAnnotation.iso}}", "{{entry2.value.dateTimeFormatAnnotation.pattern | raw}}", "{{entry2.value.dateTimeFormatAnnotation.style}}", "{{entry2.value.dateTimeFormatAnnotation.fallbackPatterns | join('","') | raw}}");#}
-            {% else %}
-            requestedFor.withQueryParam("{{entry2.value.name}}", equalTo(String.valueOf({{entry2.value.name}})));
-{#                url = url + "{{entry2.value.name}}=" + {{entry2.value.name}};#}
-            {% endif %}
-        {% endif %}
-}
-    {% endfor %}
-{% endmacro %}
-
 {% macro addQueryParamsToMappingBuilder(entry) %}
     {% for entry2 in entry.value.requestParameters %}
         {% if entry2.value.optional %}
@@ -311,6 +286,27 @@ if ({{entry2.value.name}} != null) {
         {% if entry2.value.optional %}
             }
         {% endif %}
+    {% endfor %}
+{% endmacro %}
+
+{% macro addRequestParamsToPatternBuilder(entry) %}
+    {% for entry2 in entry.value.requestParameters %}
+if ({{entry2.value.name}} != null) {
+        {% if entry2.value.iterable %}
+            url = url + "{{entry2.value.name}}=";
+            {% if entry2.value.dateTimeFormatAnnotation is not empty %}
+            requestPatternBuilder.withQueryParam("{{entry2.value.name}}", havingExactly({{entry2.value.name}}.stream().map(x -> serialise(x, "{{entry2.value.dateTimeFormatAnnotation.clazz}}", "{{entry2.value.dateTimeFormatAnnotation.iso}}", "{{entry2.value.dateTimeFormatAnnotation.pattern | raw}}", "{{entry2.value.dateTimeFormatAnnotation.style}}", "{{entry2.value.dateTimeFormatAnnotation.fallbackPatterns | join('","') | raw}}")).toArray(String[]::new)));
+            {% else %}
+            requestPatternBuilder.withQueryParam("{{entry2.value.name}}", havingExactly({{entry2.value.name}}.stream().map(x -> x.toString()).toArray(String[]::new)));
+            {% endif %}
+            {% else %}
+            {% if entry2.value.dateTimeFormatAnnotation is not empty %}
+            requestPatternBuilder.withQueryParam("{{entry2.value.name}}", equalTo(serialise({{entry2.value.name}}, "{{entry2.value.dateTimeFormatAnnotation.clazz}}", "{{entry2.value.dateTimeFormatAnnotation.iso}}", "{{entry2.value.dateTimeFormatAnnotation.pattern | raw}}", "{{entry2.value.dateTimeFormatAnnotation.style}}", "{{entry2.value.dateTimeFormatAnnotation.fallbackPatterns | join('","') | raw}}")));
+            {% else %}
+            requestPatternBuilder.withQueryParam("{{entry2.value.name}}", equalTo(String.valueOf({{entry2.value.name}})));
+            {% endif %}
+        {% endif %}
+}
     {% endfor %}
 {% endmacro %}
 

--- a/generator/src/main/resources/templates/Stub.peb
+++ b/generator/src/main/resources/templates/Stub.peb
@@ -95,56 +95,33 @@ public class {{model.stubClassName}} {
     public void verify{{entry.value.methodName}}({{ entry.value.verifyMethodArgumentListWithTimes | join(', ') | raw}}) {
         {{ generateUrlWithPathVariables(entry) }}
         RequestPatternBuilder requestPatternBuilder = {{entry.value.httpMethod.name() | lower}}RequestedFor(urlPathEqualTo(url));
-        {% if entry.value.hasOptionalMultiValueRequestParams %}
-            {{ addQueryParamsToRequestPatternBuilder(entry) }}
-            verify(times, requestPatternBuilder
-                {% if entry.value.requestBody is not empty%}
-                .withRequestBody(equalToJson(buildBody({{ entry.value.requestBody.name }})))
-                {% endif %}
-            );
-        {% else %}
-            {{ addQueryParamsToRequestPatternBuilder(entry) }}
-            {{ addRequestHeadersToRequestPatternBuilder(entry) }}
-            {% if entry.value.requestBody is not empty%}
-                requestPatternBuilder.withRequestBody(equalToJson(buildBody({{ entry.value.requestBody.name }})));
-            {% endif %}
-            verify(times, requestPatternBuilder);
+        {{ addQueryParamsToRequestPatternBuilder(entry) }}
+        {{ addRequestHeadersToRequestPatternBuilder(entry) }}
+        {% if entry.value.requestBody is not empty%}
+            requestPatternBuilder.withRequestBody(equalToJson(buildBody({{ entry.value.requestBody.name }})));
         {% endif %}
+        verify(times, requestPatternBuilder);
     }
 
     {% if entry.value.verifyMethodArgumentListWithTimesWithoutBody != entry.value.verifyMethodArgumentListWithTimes %}
     public void verify{{entry.value.methodName}}({{ entry.value.verifyMethodArgumentListWithTimesWithoutBody | join(', ') | raw}}) {
         {{ generateUrlWithPathVariables(entry) }}
         RequestPatternBuilder requestPatternBuilder = {{entry.value.httpMethod.name() | lower}}RequestedFor(urlPathEqualTo(url));
-        {% if entry.value.hasOptionalMultiValueRequestParams %}
-            {{ addQueryParamsToRequestPatternBuilder(entry) }}
-            verify(times, requestPatternBuilder);
-        {% else %}
-            {{ addQueryParamsToRequestPatternBuilder(entry) }}
-            {{ addRequestHeadersToRequestPatternBuilder(entry) }}
-            verify(times, requestPatternBuilder);
-        {% endif %}
+        {{ addQueryParamsToRequestPatternBuilder(entry) }}
+        {{ addRequestHeadersToRequestPatternBuilder(entry) }}
+        verify(times, requestPatternBuilder);
     }
     {% endif %}
 
     public void verify{{entry.value.methodName}}NoInteraction({{ entry.value.verifyMethodArgumentList | join(', ') | raw}}) {
         {{ generateUrlWithPathVariables(entry) }}
         RequestPatternBuilder requestPatternBuilder = {{entry.value.httpMethod.name() | lower}}RequestedFor(urlPathEqualTo(url));
-        {% if entry.value.hasOptionalMultiValueRequestParams %}
-            {{ addQueryParamsToRequestPatternBuilder(entry) }}
-            verify(NEVER, requestPatternBuilder
-                {% if entry.value.requestBody is not empty%}
-                .withRequestBody(equalToJson(buildBody({{ entry.value.requestBody.name }})))
-                {% endif %}
-            );
-        {% else %}
-            {{ addQueryParamsToRequestPatternBuilder(entry) }}
-            {{ addRequestHeadersToRequestPatternBuilder(entry) }}
-            {% if entry.value.requestBody is not empty%}
-                requestPatternBuilder.withRequestBody(equalToJson(buildBody({{ entry.value.requestBody.name }})));
-            {% endif %}
-            verify(NEVER, requestPatternBuilder);
+        {{ addQueryParamsToRequestPatternBuilder(entry) }}
+        {{ addRequestHeadersToRequestPatternBuilder(entry) }}
+        {% if entry.value.requestBody is not empty%}
+            requestPatternBuilder.withRequestBody(equalToJson(buildBody({{ entry.value.requestBody.name }})));
         {% endif %}
+        verify(NEVER, requestPatternBuilder);
     }
 
     {% if not entry.value.hasOptionalMultiValueRequestParams and entry.value.verifyMethodArgumentList != entry.value.verifyMethodArgumentListPathVariablesOnly %}

--- a/generator/src/main/resources/templates/Stub.peb
+++ b/generator/src/main/resources/templates/Stub.peb
@@ -101,8 +101,7 @@ public class {{model.stubClassName}} {
                 {% endif %}
             );
         {% else %}
-            RequestPatternBuilder requestPatternBuilder = {{entry.value.httpMethod.name() | lower}}RequestedFor(urlPathEqualTo(format(url)));
-            {{ addQueryParamsToRequestPatternBuilder(entry) }}
+            {{ addRequestParamsToPatternBuilder(entry) }}
             {{ addRequestHeadersToRequestPatternBuilder(entry) }}
             {% if entry.value.requestBody is not empty%}
                 requestPatternBuilder.withRequestBody(equalToJson(buildBody({{ entry.value.requestBody.name }})));
@@ -119,8 +118,7 @@ public class {{model.stubClassName}} {
             {{ addRequestParamsToPatternBuilder(entry) }}
             verify(times, requestPatternBuilder);
         {% else %}
-            RequestPatternBuilder requestPatternBuilder = {{entry.value.httpMethod.name() | lower}}RequestedFor(urlPathEqualTo(format(url)));
-            {{ addQueryParamsToRequestPatternBuilder(entry) }}
+            {{ addRequestParamsToPatternBuilder(entry) }}
             {{ addRequestHeadersToRequestPatternBuilder(entry) }}
             verify(times, requestPatternBuilder);
         {% endif %}
@@ -138,8 +136,7 @@ public class {{model.stubClassName}} {
                 {% endif %}
             );
         {% else %}
-            RequestPatternBuilder requestPatternBuilder = {{entry.value.httpMethod.name() | lower}}RequestedFor(urlPathEqualTo(format(url)));
-            {{ addQueryParamsToRequestPatternBuilder(entry) }}
+            {{ addRequestParamsToPatternBuilder(entry) }}
             {{ addRequestHeadersToRequestPatternBuilder(entry) }}
             {% if entry.value.requestBody is not empty%}
                 requestPatternBuilder.withRequestBody(equalToJson(buildBody({{ entry.value.requestBody.name }})));
@@ -273,25 +270,11 @@ if ({{entry2.value.name}} != null) {
     {% endfor %}
 {% endmacro %}
 
-{% macro addQueryParamsToRequestPatternBuilder(entry) %}
-    {% for entry2 in entry.value.requestParameters %}
-        {% if entry2.value.optional %}
-            if ({{entry2.value.name}} != null) {
-        {% endif %}
-        {% if entry2.value.dateTimeFormatAnnotation is not empty %}
-            requestPatternBuilder.withQueryParam("{{entry2.value.name}}", equalTo(serialise({{entry2.value.name}}, "{{entry2.value.dateTimeFormatAnnotation.clazz}}", "{{entry2.value.dateTimeFormatAnnotation.iso}}", "{{entry2.value.dateTimeFormatAnnotation.pattern | raw}}", "{{entry2.value.dateTimeFormatAnnotation.style}}", "{{entry2.value.dateTimeFormatAnnotation.fallbackPatterns | join('","') | raw}}")));
-        {% else %}
-            requestPatternBuilder.withQueryParam("{{entry2.value.name}}", equalTo(String.valueOf({{entry2.value.name}})));
-        {% endif %}
-        {% if entry2.value.optional %}
-            }
-        {% endif %}
-    {% endfor %}
-{% endmacro %}
-
 {% macro addRequestParamsToPatternBuilder(entry) %}
     {% for entry2 in entry.value.requestParameters %}
+        {% if entry2.value.optional %}
 if ({{entry2.value.name}} != null) {
+        {% endif %}
         {% if entry2.value.iterable %}
             url = url + "{{entry2.value.name}}=";
             {% if entry2.value.dateTimeFormatAnnotation is not empty %}
@@ -299,14 +282,16 @@ if ({{entry2.value.name}} != null) {
             {% else %}
             requestPatternBuilder.withQueryParam("{{entry2.value.name}}", havingExactly({{entry2.value.name}}.stream().map(x -> x.toString()).toArray(String[]::new)));
             {% endif %}
-            {% else %}
+        {% else %}
             {% if entry2.value.dateTimeFormatAnnotation is not empty %}
             requestPatternBuilder.withQueryParam("{{entry2.value.name}}", equalTo(serialise({{entry2.value.name}}, "{{entry2.value.dateTimeFormatAnnotation.clazz}}", "{{entry2.value.dateTimeFormatAnnotation.iso}}", "{{entry2.value.dateTimeFormatAnnotation.pattern | raw}}", "{{entry2.value.dateTimeFormatAnnotation.style}}", "{{entry2.value.dateTimeFormatAnnotation.fallbackPatterns | join('","') | raw}}")));
             {% else %}
             requestPatternBuilder.withQueryParam("{{entry2.value.name}}", equalTo(String.valueOf({{entry2.value.name}})));
             {% endif %}
         {% endif %}
+        {% if entry2.value.optional %}
 }
+        {% endif %}
     {% endfor %}
 {% endmacro %}
 

--- a/generator/src/main/resources/templates/Stub.peb
+++ b/generator/src/main/resources/templates/Stub.peb
@@ -50,11 +50,12 @@ public class {{model.stubClassName}} {
 
     public void {{decapitaliseFirstLetterOf(entry.value.methodName)}}({{ entry.value.stubMethodArgumentList | join(', ') | raw}}) {
         {{ generateUrlWithPathVariables(entry) }}
-        MappingBuilder mappingBuilder = {{entry.value.httpMethod.name() | lower}}(urlPathEqualTo(url));
-        {% if entry.value.hasMultiValueRequestParams %}
+        {% if entry.value.hasOptionalMultiValueRequestParams %}
             {{ addRequestParamsToUrl(entry) }}
+            MappingBuilder mappingBuilder = {{entry.value.httpMethod.name() | lower}}(urlEqualTo(url));
             stub({% if entry.value.responseStatus is empty%}OK{% else %}{{ entry.value.responseStatus }}{% endif %}, {% if entry.value.responseType is not empty%}buildBody(response){% else %}null{% endif %}, mappingBuilder);
         {% else %}
+            MappingBuilder mappingBuilder = {{entry.value.httpMethod.name() | lower}}(urlPathEqualTo(url));
             {{ addQueryParamsToMappingBuilder(entry) }}
             stub({% if entry.value.responseStatus is empty%}OK{% else %}{{ entry.value.responseStatus }}{% endif %}, {% if entry.value.responseType is not empty%}buildBody(response){% else %}null{% endif %}, mappingBuilder);
         {% endif %}
@@ -63,11 +64,12 @@ public class {{model.stubClassName}} {
     {% if entry.value.requestBody != null and ["POST", "PUT"] contains entry.value.httpMethod.name() %}
     public void {{decapitaliseFirstLetterOf(entry.value.methodName)}}({{ entry.value.stubMethodArgumentListWithRequest | join(', ') | raw}}) {
         {{ generateUrlWithPathVariables(entry) }}
-        MappingBuilder mappingBuilder = {{entry.value.httpMethod.name() | lower}}(urlPathEqualTo(url)).withRequestBody(equalToJson(buildBody({{ entry.value.requestBody.name }})));
-        {% if entry.value.hasMultiValueRequestParams %}
+        {% if entry.value.hasOptionalMultiValueRequestParams %}
             {{ addRequestParamsToUrl(entry) }}
+            MappingBuilder mappingBuilder = {{entry.value.httpMethod.name() | lower}}(urlEqualTo(url)).withRequestBody(equalToJson(buildBody({{ entry.value.requestBody.name }})));
             stub({% if entry.value.responseStatus is empty%}OK{% else %}{{ entry.value.responseStatus }}{% endif %}, {% if entry.value.responseType is not empty%}buildBody(response){% else %}null{% endif %}, mappingBuilder);
         {% else %}
+            MappingBuilder mappingBuilder = {{entry.value.httpMethod.name() | lower}}(urlPathEqualTo(url)).withRequestBody(equalToJson(buildBody({{ entry.value.requestBody.name }})));
             {{ addQueryParamsToMappingBuilder(entry) }}
             stub({% if entry.value.responseStatus is empty%}OK{% else %}{{ entry.value.responseStatus }}{% endif %}, {% if entry.value.responseType is not empty%}buildBody(response){% else %}null{% endif %}, mappingBuilder);
         {% endif %}
@@ -76,7 +78,7 @@ public class {{model.stubClassName}} {
 
     public void {{decapitaliseFirstLetterOf(entry.value.methodName)}}({{ entry.value.stubMethodArgumentListForCustomResponse | join(', ') | raw}}) {
         {{ generateUrlWithPathVariables(entry) }}
-        {% if entry.value.hasMultiValueRequestParams %}
+        {% if entry.value.hasOptionalMultiValueRequestParams %}
             {{ addRequestParamsToUrl(entry) }}
             stub(httpStatus, response, {{entry.value.httpMethod.name() | lower}}(urlEqualTo(url)));
         {% else %}
@@ -93,7 +95,7 @@ public class {{model.stubClassName}} {
     public void verify{{entry.value.methodName}}({{ entry.value.verifyMethodArgumentListWithTimes | join(', ') | raw}}) {
         {{ generateUrlWithPathVariables(entry) }}
         RequestPatternBuilder requestPatternBuilder = {{entry.value.httpMethod.name() | lower}}RequestedFor(urlPathEqualTo(url));
-        {% if entry.value.hasMultiValueRequestParams %}
+        {% if entry.value.hasOptionalMultiValueRequestParams %}
             {{ addQueryParamsToRequestPatternBuilder(entry) }}
             verify(times, requestPatternBuilder
                 {% if entry.value.requestBody is not empty%}
@@ -114,7 +116,7 @@ public class {{model.stubClassName}} {
     public void verify{{entry.value.methodName}}({{ entry.value.verifyMethodArgumentListWithTimesWithoutBody | join(', ') | raw}}) {
         {{ generateUrlWithPathVariables(entry) }}
         RequestPatternBuilder requestPatternBuilder = {{entry.value.httpMethod.name() | lower}}RequestedFor(urlPathEqualTo(url));
-        {% if entry.value.hasMultiValueRequestParams %}
+        {% if entry.value.hasOptionalMultiValueRequestParams %}
             {{ addQueryParamsToRequestPatternBuilder(entry) }}
             verify(times, requestPatternBuilder);
         {% else %}
@@ -128,7 +130,7 @@ public class {{model.stubClassName}} {
     public void verify{{entry.value.methodName}}NoInteraction({{ entry.value.verifyMethodArgumentList | join(', ') | raw}}) {
         {{ generateUrlWithPathVariables(entry) }}
         RequestPatternBuilder requestPatternBuilder = {{entry.value.httpMethod.name() | lower}}RequestedFor(urlPathEqualTo(url));
-        {% if entry.value.hasMultiValueRequestParams %}
+        {% if entry.value.hasOptionalMultiValueRequestParams %}
             {{ addQueryParamsToRequestPatternBuilder(entry) }}
             verify(NEVER, requestPatternBuilder
                 {% if entry.value.requestBody is not empty%}
@@ -145,7 +147,7 @@ public class {{model.stubClassName}} {
         {% endif %}
     }
 
-    {% if not entry.value.hasMultiValueRequestParams and entry.value.verifyMethodArgumentList != entry.value.verifyMethodArgumentListPathVariablesOnly %}
+    {% if not entry.value.hasOptionalMultiValueRequestParams and entry.value.verifyMethodArgumentList != entry.value.verifyMethodArgumentListPathVariablesOnly %}
     public void verify{{entry.value.methodName}}NoInteraction({{ entry.value.verifyMethodArgumentListPathVariablesOnly | join(', ') | raw}}) {
         {{ generateUrlWithPathVariables(entry) }}
         verify(NEVER, {{entry.value.httpMethod.name() | lower}}RequestedFor(urlPathEqualTo(url)));
@@ -254,18 +256,30 @@ if ({{entry2.value.name}} != null) {
 
 {% macro addQueryParamsToMappingBuilder(entry) %}
     {% for entry2 in entry.value.requestParameters %}
-        {% if entry2.value.optional %}
+        {% if entry2.value.iterable %}
+            {#Optional iterable cannot be handled with mapping builder.  #}
             {% if entry2.value.dateTimeFormatAnnotation is not empty %}
-                mappingBuilder.withQueryParam("{{entry2.value.name}}", equalTo(serialise({{entry2.value.name}}, "{{entry2.value.dateTimeFormatAnnotation.clazz}}", "{{entry2.value.dateTimeFormatAnnotation.iso}}", "{{entry2.value.dateTimeFormatAnnotation.pattern | raw}}", "{{entry2.value.dateTimeFormatAnnotation.style}}", "{{entry2.value.dateTimeFormatAnnotation.fallbackPatterns | join('","') | raw}}")).or(absent()));
+                mappingBuilder.withQueryParam("{{entry2.value.name}}", havingExactly({{entry2.value.name}}.stream().map(x -> serialise(x, "{{entry2.value.dateTimeFormatAnnotation.clazz}}", "{{entry2.value.dateTimeFormatAnnotation.iso}}", "{{entry2.value.dateTimeFormatAnnotation.pattern | raw}}", "{{entry2.value.dateTimeFormatAnnotation.style}}", "{{entry2.value.dateTimeFormatAnnotation.fallbackPatterns | join('","') | raw}}")).toArray(String[]::new)));
             {% else %}
-                mappingBuilder.withQueryParam("{{entry2.value.name}}", equalTo(String.valueOf({{entry2.value.name}})).or(absent()));
+                mappingBuilder.withQueryParam("{{entry2.value.name}}", havingExactly({{entry2.value.name}}.stream().map(x -> x.toString()).toArray(String[]::new)));
             {% endif %}
+
         {% else %}
-            {% if entry2.value.dateTimeFormatAnnotation is not empty %}
-                mappingBuilder.withQueryParam("{{entry2.value.name}}", equalTo(serialise({{entry2.value.name}}, "{{entry2.value.dateTimeFormatAnnotation.clazz}}", "{{entry2.value.dateTimeFormatAnnotation.iso}}", "{{entry2.value.dateTimeFormatAnnotation.pattern | raw}}", "{{entry2.value.dateTimeFormatAnnotation.style}}", "{{entry2.value.dateTimeFormatAnnotation.fallbackPatterns | join('","') | raw}}")));
+
+            {% if entry2.value.optional %}
+                {% if entry2.value.dateTimeFormatAnnotation is not empty %}
+                    mappingBuilder.withQueryParam("{{entry2.value.name}}", equalTo(serialise({{entry2.value.name}}, "{{entry2.value.dateTimeFormatAnnotation.clazz}}", "{{entry2.value.dateTimeFormatAnnotation.iso}}", "{{entry2.value.dateTimeFormatAnnotation.pattern | raw}}", "{{entry2.value.dateTimeFormatAnnotation.style}}", "{{entry2.value.dateTimeFormatAnnotation.fallbackPatterns | join('","') | raw}}")).or(absent()));
+                {% else %}
+                    mappingBuilder.withQueryParam("{{entry2.value.name}}", equalTo(String.valueOf({{entry2.value.name}})).or(absent()));
+                {% endif %}
             {% else %}
-                mappingBuilder.withQueryParam("{{entry2.value.name}}", equalTo(String.valueOf({{entry2.value.name}})));
+                {% if entry2.value.dateTimeFormatAnnotation is not empty %}
+                    mappingBuilder.withQueryParam("{{entry2.value.name}}", equalTo(serialise({{entry2.value.name}}, "{{entry2.value.dateTimeFormatAnnotation.clazz}}", "{{entry2.value.dateTimeFormatAnnotation.iso}}", "{{entry2.value.dateTimeFormatAnnotation.pattern | raw}}", "{{entry2.value.dateTimeFormatAnnotation.style}}", "{{entry2.value.dateTimeFormatAnnotation.fallbackPatterns | join('","') | raw}}")));
+                {% else %}
+                    mappingBuilder.withQueryParam("{{entry2.value.name}}", equalTo(String.valueOf({{entry2.value.name}})));
+                {% endif %}
             {% endif %}
+
         {% endif %}
     {% endfor %}
 {% endmacro %}

--- a/generator/src/main/resources/templates/Stub.peb
+++ b/generator/src/main/resources/templates/Stub.peb
@@ -276,7 +276,6 @@ if ({{entry2.value.name}} != null) {
 if ({{entry2.value.name}} != null) {
         {% endif %}
         {% if entry2.value.iterable %}
-            url = url + "{{entry2.value.name}}=";
             {% if entry2.value.dateTimeFormatAnnotation is not empty %}
             requestPatternBuilder.withQueryParam("{{entry2.value.name}}", havingExactly({{entry2.value.name}}.stream().map(x -> serialise(x, "{{entry2.value.dateTimeFormatAnnotation.clazz}}", "{{entry2.value.dateTimeFormatAnnotation.iso}}", "{{entry2.value.dateTimeFormatAnnotation.pattern | raw}}", "{{entry2.value.dateTimeFormatAnnotation.style}}", "{{entry2.value.dateTimeFormatAnnotation.fallbackPatterns | join('","') | raw}}")).toArray(String[]::new)));
             {% else %}

--- a/generator/src/main/resources/templates/Stub.peb
+++ b/generator/src/main/resources/templates/Stub.peb
@@ -229,6 +229,7 @@ String url = String.format({{entry.value.methodName.toUpperCase()}}_URL{% for en
 
 {% macro addRequestParamsToUrl(entry) %}
     {% for entry2 in entry.value.requestParameters %}
+if ({{entry2.value.name}} != null) {
         {% if loop.first %}
             url = url + "?";
         {% else %}
@@ -248,6 +249,7 @@ String url = String.format({{entry.value.methodName.toUpperCase()}}_URL{% for en
                 url = url + "{{entry2.value.name}}=" + {{entry2.value.name}};
             {% endif %}
         {% endif %}
+}
     {% endfor %}
 {% endmacro %}
 

--- a/generator/src/main/resources/templates/Stub.peb
+++ b/generator/src/main/resources/templates/Stub.peb
@@ -49,7 +49,7 @@ public class {{model.stubClassName}} {
     public static final String {{entry.value.methodName.toUpperCase()}}_URL = "{{model.rootResource}}{{entry.value.subResource}}";
 
     public void {{decapitaliseFirstLetterOf(entry.value.methodName)}}({{ entry.value.stubMethodArgumentList | join(', ') | raw}}) {
-        {{ generateUrl(entry) }}
+        {{ generateUrlWithPathVariables(entry) }}
         MappingBuilder mappingBuilder = {{entry.value.httpMethod.name() | lower}}(urlPathEqualTo(url));
         {% if entry.value.hasMultiValueRequestParams %}
             {{ addRequestParamsToUrl(entry) }}
@@ -62,7 +62,7 @@ public class {{model.stubClassName}} {
 
     {% if entry.value.requestBody != null and ["POST", "PUT"] contains entry.value.httpMethod.name() %}
     public void {{decapitaliseFirstLetterOf(entry.value.methodName)}}({{ entry.value.stubMethodArgumentListWithRequest | join(', ') | raw}}) {
-        {{ generateUrl(entry) }}
+        {{ generateUrlWithPathVariables(entry) }}
         MappingBuilder mappingBuilder = {{entry.value.httpMethod.name() | lower}}(urlPathEqualTo(url)).withRequestBody(equalToJson(buildBody({{ entry.value.requestBody.name }})));
         {% if entry.value.hasMultiValueRequestParams %}
             {{ addRequestParamsToUrl(entry) }}
@@ -75,7 +75,7 @@ public class {{model.stubClassName}} {
     {% endif %}
 
     public void {{decapitaliseFirstLetterOf(entry.value.methodName)}}({{ entry.value.stubMethodArgumentListForCustomResponse | join(', ') | raw}}) {
-        {{ generateUrl(entry) }}
+        {{ generateUrlWithPathVariables(entry) }}
         {% if entry.value.hasMultiValueRequestParams %}
             {{ addRequestParamsToUrl(entry) }}
             stub(httpStatus, response, {{entry.value.httpMethod.name() | lower}}(urlEqualTo(url)));
@@ -91,10 +91,11 @@ public class {{model.stubClassName}} {
     }
 
     public void verify{{entry.value.methodName}}({{ entry.value.verifyMethodArgumentListWithTimes | join(', ') | raw}}) {
-        {{ generateUrl(entry) }}
+        {{ generateUrlWithPathVariables(entry) }}
+        RequestPatternBuilder requestedFor = {{entry.value.httpMethod.name() | lower}}RequestedFor(urlPathEqualTo(url));
         {% if entry.value.hasMultiValueRequestParams %}
-            {{ addRequestParamsToUrl(entry) }}
-            verify(times, {{entry.value.httpMethod.name() | lower}}RequestedFor(urlEqualTo(url))
+            {{ addRequestParamsToPatternBuilder(entry) }}
+            verify(times, requestedFor
                 {% if entry.value.requestBody is not empty%}
                 .withRequestBody(equalToJson(buildBody({{ entry.value.requestBody.name }})))
                 {% endif %}
@@ -112,11 +113,11 @@ public class {{model.stubClassName}} {
 
     {% if entry.value.verifyMethodArgumentListWithTimesWithoutBody != entry.value.verifyMethodArgumentListWithTimes %}
     public void verify{{entry.value.methodName}}({{ entry.value.verifyMethodArgumentListWithTimesWithoutBody | join(', ') | raw}}) {
-        {{ generateUrl(entry) }}
+        {{ generateUrlWithPathVariables(entry) }}
+        RequestPatternBuilder requestedFor = {{entry.value.httpMethod.name() | lower}}RequestedFor(urlPathEqualTo(url));
         {% if entry.value.hasMultiValueRequestParams %}
-            {{ addRequestParamsToUrl(entry) }}
-            verify(times, {{entry.value.httpMethod.name() | lower}}RequestedFor(urlEqualTo(url))
-            );
+            {{ addRequestParamsToPatternBuilder(entry) }}
+            verify(times, requestedFor);
         {% else %}
             RequestPatternBuilder requestPatternBuilder = {{entry.value.httpMethod.name() | lower}}RequestedFor(urlPathEqualTo(format(url)));
             {{ addQueryParamsToRequestPatternBuilder(entry) }}
@@ -127,10 +128,11 @@ public class {{model.stubClassName}} {
     {% endif %}
 
     public void verify{{entry.value.methodName}}NoInteraction({{ entry.value.verifyMethodArgumentList | join(', ') | raw}}) {
-        {{ generateUrl(entry) }}
+        {{ generateUrlWithPathVariables(entry) }}
+        RequestPatternBuilder requestedFor = {{entry.value.httpMethod.name() | lower}}RequestedFor(urlPathEqualTo(url));
         {% if entry.value.hasMultiValueRequestParams %}
-            {{ addRequestParamsToUrl(entry) }}
-            verify(NEVER, {{entry.value.httpMethod.name() | lower}}RequestedFor(urlEqualTo(url))
+            {{ addRequestParamsToPatternBuilder(entry) }}
+            verify(NEVER, requestedFor
                 {% if entry.value.requestBody is not empty%}
                 .withRequestBody(equalToJson(buildBody({{ entry.value.requestBody.name }})))
                 {% endif %}
@@ -148,7 +150,7 @@ public class {{model.stubClassName}} {
 
     {% if not entry.value.hasMultiValueRequestParams and entry.value.verifyMethodArgumentList != entry.value.verifyMethodArgumentListPathVariablesOnly %}
     public void verify{{entry.value.methodName}}NoInteraction({{ entry.value.verifyMethodArgumentListPathVariablesOnly | join(', ') | raw}}) {
-        {{ generateUrl(entry) }}
+        {{ generateUrlWithPathVariables(entry) }}
         verify(NEVER, {{entry.value.httpMethod.name() | lower}}RequestedFor(urlPathEqualTo(url)));
     }
     {% endif %}
@@ -219,7 +221,7 @@ public class {{model.stubClassName}} {
     }
 {% endif %}
 }
-{% macro generateUrl(entry) %}
+{% macro generateUrlWithPathVariables(entry) %}
 String url = String.format({{entry.value.methodName.toUpperCase()}}_URL{% for entry2 in entry.value.pathVariables %}, {{entry2.value.name}} {% endfor %});
 {% endmacro %}
 
@@ -247,6 +249,31 @@ if ({{entry2.value.name}} != null) {
                 url = url + "{{entry2.value.name}}=" + serialise({{entry2.value.name}}, "{{entry2.value.dateTimeFormatAnnotation.clazz}}", "{{entry2.value.dateTimeFormatAnnotation.iso}}", "{{entry2.value.dateTimeFormatAnnotation.pattern | raw}}", "{{entry2.value.dateTimeFormatAnnotation.style}}", "{{entry2.value.dateTimeFormatAnnotation.fallbackPatterns | join('","') | raw}}");
             {% else %}
                 url = url + "{{entry2.value.name}}=" + {{entry2.value.name}};
+            {% endif %}
+        {% endif %}
+}
+    {% endfor %}
+{% endmacro %}
+
+{% macro addRequestParamsToPatternBuilder(entry) %}
+    {% for entry2 in entry.value.requestParameters %}
+if ({{entry2.value.name}} != null) {
+        {% if entry2.value.iterable %}
+            url = url + "{{entry2.value.name}}=";
+            {% if entry2.value.dateTimeFormatAnnotation is not empty %}
+            requestedFor.withQueryParam("{{entry2.value.name}}", havingExactly({{entry2.value.name}}.stream().map(x -> serialise(x, "{{entry2.value.dateTimeFormatAnnotation.clazz}}", "{{entry2.value.dateTimeFormatAnnotation.iso}}", "{{entry2.value.dateTimeFormatAnnotation.pattern | raw}}", "{{entry2.value.dateTimeFormatAnnotation.style}}", "{{entry2.value.dateTimeFormatAnnotation.fallbackPatterns | join('","') | raw}}")).toArray(String[]::new)));
+{#                url = url + String.join("&{{entry2.value.name}}=", {{entry2.value.name}}.stream().map(x -> serialise(x, "{{entry2.value.dateTimeFormatAnnotation.clazz}}", "{{entry2.value.dateTimeFormatAnnotation.iso}}", "{{entry2.value.dateTimeFormatAnnotation.pattern | raw}}", "{{entry2.value.dateTimeFormatAnnotation.style}}", "{{entry2.value.dateTimeFormatAnnotation.fallbackPatterns | join('","') | raw}}")).collect(toList()));#}
+            {% else %}
+            requestedFor.withQueryParam("{{entry2.value.name}}", havingExactly({{entry2.value.name}}.stream().map(x -> x.toString()).toArray(String[]::new)));
+{#                url = url + String.join("&{{entry2.value.name}}=", {{entry2.value.name}}.stream().map(x -> x.toString()).collect(toList()));#}
+            {% endif %}
+        {% else %}
+            {% if entry2.value.dateTimeFormatAnnotation is not empty %}
+            requestedFor.withQueryParam("{{entry2.value.name}}", equalTo(serialise({{entry2.value.name}}, "{{entry2.value.dateTimeFormatAnnotation.clazz}}", "{{entry2.value.dateTimeFormatAnnotation.iso}}", "{{entry2.value.dateTimeFormatAnnotation.pattern | raw}}", "{{entry2.value.dateTimeFormatAnnotation.style}}", "{{entry2.value.dateTimeFormatAnnotation.fallbackPatterns | join('","') | raw}}")));
+{#                url = url + "{{entry2.value.name}}=" + serialise({{entry2.value.name}}, "{{entry2.value.dateTimeFormatAnnotation.clazz}}", "{{entry2.value.dateTimeFormatAnnotation.iso}}", "{{entry2.value.dateTimeFormatAnnotation.pattern | raw}}", "{{entry2.value.dateTimeFormatAnnotation.style}}", "{{entry2.value.dateTimeFormatAnnotation.fallbackPatterns | join('","') | raw}}");#}
+            {% else %}
+            requestedFor.withQueryParam("{{entry2.value.name}}", equalTo(String.valueOf({{entry2.value.name}})));
+{#                url = url + "{{entry2.value.name}}=" + {{entry2.value.name}};#}
             {% endif %}
         {% endif %}
 }

--- a/generator/src/main/resources/templates/Stub.peb
+++ b/generator/src/main/resources/templates/Stub.peb
@@ -94,14 +94,14 @@ public class {{model.stubClassName}} {
         {{ generateUrlWithPathVariables(entry) }}
         RequestPatternBuilder requestPatternBuilder = {{entry.value.httpMethod.name() | lower}}RequestedFor(urlPathEqualTo(url));
         {% if entry.value.hasMultiValueRequestParams %}
-            {{ addRequestParamsToPatternBuilder(entry) }}
+            {{ addQueryParamsToRequestPatternBuilder(entry) }}
             verify(times, requestPatternBuilder
                 {% if entry.value.requestBody is not empty%}
                 .withRequestBody(equalToJson(buildBody({{ entry.value.requestBody.name }})))
                 {% endif %}
             );
         {% else %}
-            {{ addRequestParamsToPatternBuilder(entry) }}
+            {{ addQueryParamsToRequestPatternBuilder(entry) }}
             {{ addRequestHeadersToRequestPatternBuilder(entry) }}
             {% if entry.value.requestBody is not empty%}
                 requestPatternBuilder.withRequestBody(equalToJson(buildBody({{ entry.value.requestBody.name }})));
@@ -115,10 +115,10 @@ public class {{model.stubClassName}} {
         {{ generateUrlWithPathVariables(entry) }}
         RequestPatternBuilder requestPatternBuilder = {{entry.value.httpMethod.name() | lower}}RequestedFor(urlPathEqualTo(url));
         {% if entry.value.hasMultiValueRequestParams %}
-            {{ addRequestParamsToPatternBuilder(entry) }}
+            {{ addQueryParamsToRequestPatternBuilder(entry) }}
             verify(times, requestPatternBuilder);
         {% else %}
-            {{ addRequestParamsToPatternBuilder(entry) }}
+            {{ addQueryParamsToRequestPatternBuilder(entry) }}
             {{ addRequestHeadersToRequestPatternBuilder(entry) }}
             verify(times, requestPatternBuilder);
         {% endif %}
@@ -129,14 +129,14 @@ public class {{model.stubClassName}} {
         {{ generateUrlWithPathVariables(entry) }}
         RequestPatternBuilder requestPatternBuilder = {{entry.value.httpMethod.name() | lower}}RequestedFor(urlPathEqualTo(url));
         {% if entry.value.hasMultiValueRequestParams %}
-            {{ addRequestParamsToPatternBuilder(entry) }}
+            {{ addQueryParamsToRequestPatternBuilder(entry) }}
             verify(NEVER, requestPatternBuilder
                 {% if entry.value.requestBody is not empty%}
                 .withRequestBody(equalToJson(buildBody({{ entry.value.requestBody.name }})))
                 {% endif %}
             );
         {% else %}
-            {{ addRequestParamsToPatternBuilder(entry) }}
+            {{ addQueryParamsToRequestPatternBuilder(entry) }}
             {{ addRequestHeadersToRequestPatternBuilder(entry) }}
             {% if entry.value.requestBody is not empty%}
                 requestPatternBuilder.withRequestBody(equalToJson(buildBody({{ entry.value.requestBody.name }})));
@@ -270,7 +270,7 @@ if ({{entry2.value.name}} != null) {
     {% endfor %}
 {% endmacro %}
 
-{% macro addRequestParamsToPatternBuilder(entry) %}
+{% macro addQueryParamsToRequestPatternBuilder(entry) %}
     {% for entry2 in entry.value.requestParameters %}
         {% if entry2.value.optional %}
 if ({{entry2.value.name}} != null) {


### PR DESCRIPTION
This PR includes:

- Improved handling of multi-value query parameters - handle any order of query parameters
- Improved handling of optional multi-value query parameters - ordering still matters, but it handles now missing first parameter correctly
- Major refactoring of the `Stub.peb` template to simplify the logic and remove duplication

Generally, this PR decreases the reliance on URL matching in favour of the WireMock's `RequestMappingBuilder` which provides full flexibility in terms of query parameter ordering. Unfortunately, it doesn't seem to support `or` which is necessary for optional query parameters. That is still handled by matching the entire URL which is order sensitive.