### PR TITLE
#72 Handle `@RequestMapping` with multiple HTTP methods

### DIFF
--- a/generator-integration-test/src/main/kotlin/com/lsdconsulting/stub/integration/controller/get/JavaGetRestController.java
+++ b/generator-integration-test/src/main/kotlin/com/lsdconsulting/stub/integration/controller/get/JavaGetRestController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.time.ZonedDateTime;
 import java.util.Set;
 
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import static org.apache.commons.lang3.RandomStringUtils.secure;
 import static org.springframework.format.annotation.DateTimeFormat.ISO.DATE_TIME;
 
 @GenerateWireMockStub
@@ -26,13 +26,13 @@ class JavaGetRestController {
     @GetMapping("/resourceWithParamAndAnnotations")
     ResponseEntity<GreetingResponse> resourceWithParamAndAnnotations(
             @RequestParam @Valid @Email @SuppressWarnings("unused") String param) {
-        return ResponseEntity.ok().body(new GreetingResponse(randomAlphabetic(10)));
+        return ResponseEntity.ok().body(new GreetingResponse(secure().nextAlphanumeric(10)));
     }
 
     @GetMapping("/resourceWithZonedDatetimeAndMultiValue")
     GreetingResponse resourceWithZonedDatetimeAndMultiValue(
             @RequestParam @NotBlank @DateTimeFormat(iso = DATE_TIME) @SuppressWarnings("unused") ZonedDateTime param,
             @RequestParam @SuppressWarnings("unused") Set<Integer> multiValue) {
-        return new GreetingResponse(randomAlphabetic(10));
+        return new GreetingResponse(secure().nextAlphanumeric(10));
     }
 }

--- a/generator-integration-test/src/main/kotlin/com/lsdconsulting/stub/integration/controller/multiple/SimplePostPutRestController.kt
+++ b/generator-integration-test/src/main/kotlin/com/lsdconsulting/stub/integration/controller/multiple/SimplePostPutRestController.kt
@@ -4,12 +4,12 @@ import com.lsdconsulting.stub.integration.model.GreetingResponse
 import io.lsdconsulting.stub.annotation.GenerateWireMockStub
 import org.apache.commons.lang3.RandomStringUtils.secure
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestMethod.POST
-import org.springframework.web.bind.annotation.RequestMethod.PUT
+import org.springframework.web.bind.annotation.RequestMethod.*
 import org.springframework.web.bind.annotation.RestController
 
 @GenerateWireMockStub
 @RestController
+@RequestMapping(method = [DELETE, GET])
 class SimplePostPutRestController {
 
     @RequestMapping(path = ["/multipleController/postPutResource"], method = [POST, PUT])

--- a/generator-integration-test/src/main/kotlin/com/lsdconsulting/stub/integration/controller/multiple/SimplePostPutRestController.kt
+++ b/generator-integration-test/src/main/kotlin/com/lsdconsulting/stub/integration/controller/multiple/SimplePostPutRestController.kt
@@ -1,0 +1,17 @@
+package com.lsdconsulting.stub.integration.controller.multiple
+
+import com.lsdconsulting.stub.integration.model.GreetingResponse
+import io.lsdconsulting.stub.annotation.GenerateWireMockStub
+import org.apache.commons.lang3.RandomStringUtils.secure
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod.POST
+import org.springframework.web.bind.annotation.RequestMethod.PUT
+import org.springframework.web.bind.annotation.RestController
+
+@GenerateWireMockStub
+@RestController
+class SimplePostPutRestController {
+
+    @RequestMapping(path = ["/multipleController/postPutResource"], method = [POST, PUT])
+    fun postPutResourceWitNoRequestBody() = GreetingResponse(name = secure().nextAlphabetic(10))
+}

--- a/generator-integration-test/src/main/kotlin/com/lsdconsulting/stub/integration/controller/multiple/SimplePostPutRestController.kt
+++ b/generator-integration-test/src/main/kotlin/com/lsdconsulting/stub/integration/controller/multiple/SimplePostPutRestController.kt
@@ -4,12 +4,12 @@ import com.lsdconsulting.stub.integration.model.GreetingResponse
 import io.lsdconsulting.stub.annotation.GenerateWireMockStub
 import org.apache.commons.lang3.RandomStringUtils.secure
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestMethod.*
+import org.springframework.web.bind.annotation.RequestMethod.POST
+import org.springframework.web.bind.annotation.RequestMethod.PUT
 import org.springframework.web.bind.annotation.RestController
 
 @GenerateWireMockStub
 @RestController
-@RequestMapping(method = [DELETE, GET])
 class SimplePostPutRestController {
 
     @RequestMapping(path = ["/multipleController/postPutResource"], method = [POST, PUT])

--- a/generator-integration-test/src/main/kotlin/com/lsdconsulting/stub/integration/controller/post/JavaPostRestController.java
+++ b/generator-integration-test/src/main/kotlin/com/lsdconsulting/stub/integration/controller/post/JavaPostRestController.java
@@ -5,13 +5,9 @@ import com.lsdconsulting.stub.integration.model.GreetingResponse;
 import io.lsdconsulting.stub.annotation.GenerateWireMockStub;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import static org.apache.commons.lang3.RandomStringUtils.secure;
 
 @GenerateWireMockStub
 @RestController
@@ -21,13 +17,13 @@ class JavaPostRestController {
     @PostMapping("/resourceWithBodyAndAnnotations")
     GreetingResponse resourceWithBodyAndAnnotations(
             @RequestBody @Valid @Email @SuppressWarnings("unused") GreetingRequest greetingRequest) {
-        return new GreetingResponse(randomAlphabetic(10));
+        return new GreetingResponse(secure().nextAlphanumeric(10));
     }
 
     @PostMapping("/resourceWithBodyAndAnnotationsOnPathVariables/{param}")
     GreetingResponse resourceWithBodyAndAnnotationsOnPathVariables(
             @RequestBody @SuppressWarnings("unused") GreetingRequest greetingRequest,
             @PathVariable @Valid @Email @SuppressWarnings("unused") String param) {
-        return new GreetingResponse(randomAlphabetic(10));
+        return new GreetingResponse(secure().nextAlphanumeric(10));
     }
 }

--- a/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/BaseRestControllerIT.kt
+++ b/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/BaseRestControllerIT.kt
@@ -16,6 +16,7 @@ const val GET_CONTROLLER_URL = "http://localhost:8099/getController"
 const val POST_CONTROLLER_URL = "http://localhost:8099/postController"
 const val PUT_CONTROLLER_URL = "http://localhost:8099/putController"
 const val DELETE_CONTROLLER_URL = "http://localhost:8099/deleteController"
+const val MULTIPLE_METHOD_CONTROLLER_URL = "http://localhost:8099/multipleController"
 
 open class BaseRestControllerIT {
     val restTemplate = RestTemplate()

--- a/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/get/JavaGetRestControllerIT.should remove unwanted annotations from any arguments.approved
+++ b/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/get/JavaGetRestControllerIT.should remove unwanted annotations from any arguments.approved
@@ -40,8 +40,52 @@ public class JavaGetRestControllerStub {
         this.annotationFormatterFactory = annotationFormatterFactory;
     }
 
-    public static final String RESOURCEWITHZONEDDATETIMEANDMULTIVALUE_URL = "/getController/resourceWithZonedDatetimeAndMultiValue";
+    public static final String RESOURCEWITHPARAMANDANNOTATIONS_URL = "/getController/resourceWithParamAndAnnotations";
+    
+    public void resourceWithParamAndAnnotations(com.lsdconsulting.stub.integration.model.GreetingResponse response, java.lang.String param) {
+        String url = String.format(RESOURCEWITHPARAMANDANNOTATIONS_URL);
+                    MappingBuilder mappingBuilder = get(urlPathEqualTo(url));
+                        
+                                                mappingBuilder.withQueryParam("param", equalTo(String.valueOf(param)));
+                            
+                        stub(OK, buildBody(response), mappingBuilder);
+            }
 
+    
+    public void resourceWithParamAndAnnotations(int httpStatus, String response, java.lang.String param) {
+        String url = String.format(RESOURCEWITHPARAMANDANNOTATIONS_URL);
+                    MappingBuilder mappingBuilder = get(urlPathEqualTo(url));
+                    
+                                                mappingBuilder.withQueryParam("param", equalTo(String.valueOf(param)));
+                            
+                        stub(httpStatus, response, mappingBuilder);
+            }
+
+    public void verifyResourceWithParamAndAnnotations(java.lang.String param) {
+        verifyResourceWithParamAndAnnotations(ONCE, param);
+    }
+
+    public void verifyResourceWithParamAndAnnotations(final int times, java.lang.String param) {
+        String url = String.format(RESOURCEWITHPARAMANDANNOTATIONS_URL);
+        RequestPatternBuilder requestPatternBuilder = getRequestedFor(urlPathEqualTo(url));
+                                                    requestPatternBuilder.withQueryParam("param", equalTo(String.valueOf(param)));
+                                                            verify(times, requestPatternBuilder);
+    }
+
+    
+    public void verifyResourceWithParamAndAnnotationsNoInteraction(java.lang.String param) {
+        String url = String.format(RESOURCEWITHPARAMANDANNOTATIONS_URL);
+        RequestPatternBuilder requestPatternBuilder = getRequestedFor(urlPathEqualTo(url));
+                                                    requestPatternBuilder.withQueryParam("param", equalTo(String.valueOf(param)));
+                                                            verify(NEVER, requestPatternBuilder);
+    }
+
+        public void verifyResourceWithParamAndAnnotationsNoInteraction() {
+        String url = String.format(RESOURCEWITHPARAMANDANNOTATIONS_URL);
+        verify(NEVER, getRequestedFor(urlPathEqualTo(url)));
+    }
+        public static final String RESOURCEWITHZONEDDATETIMEANDMULTIVALUE_URL = "/getController/resourceWithZonedDatetimeAndMultiValue";
+    
     public void resourceWithZonedDatetimeAndMultiValue(com.lsdconsulting.stub.integration.model.GreetingResponse response, java.time.ZonedDateTime param, java.util.Set<java.lang.Integer> multiValue) {
         String url = String.format(RESOURCEWITHZONEDDATETIMEANDMULTIVALUE_URL);
                     MappingBuilder mappingBuilder = get(urlPathEqualTo(url));
@@ -88,50 +132,6 @@ public class JavaGetRestControllerStub {
 
         public void verifyResourceWithZonedDatetimeAndMultiValueNoInteraction() {
         String url = String.format(RESOURCEWITHZONEDDATETIMEANDMULTIVALUE_URL);
-        verify(NEVER, getRequestedFor(urlPathEqualTo(url)));
-    }
-        public static final String RESOURCEWITHPARAMANDANNOTATIONS_URL = "/getController/resourceWithParamAndAnnotations";
-
-    public void resourceWithParamAndAnnotations(com.lsdconsulting.stub.integration.model.GreetingResponse response, java.lang.String param) {
-        String url = String.format(RESOURCEWITHPARAMANDANNOTATIONS_URL);
-                    MappingBuilder mappingBuilder = get(urlPathEqualTo(url));
-                        
-                                                mappingBuilder.withQueryParam("param", equalTo(String.valueOf(param)));
-                            
-                        stub(OK, buildBody(response), mappingBuilder);
-            }
-
-    
-    public void resourceWithParamAndAnnotations(int httpStatus, String response, java.lang.String param) {
-        String url = String.format(RESOURCEWITHPARAMANDANNOTATIONS_URL);
-                    MappingBuilder mappingBuilder = get(urlPathEqualTo(url));
-                    
-                                                mappingBuilder.withQueryParam("param", equalTo(String.valueOf(param)));
-                            
-                        stub(httpStatus, response, mappingBuilder);
-            }
-
-    public void verifyResourceWithParamAndAnnotations(java.lang.String param) {
-        verifyResourceWithParamAndAnnotations(ONCE, param);
-    }
-
-    public void verifyResourceWithParamAndAnnotations(final int times, java.lang.String param) {
-        String url = String.format(RESOURCEWITHPARAMANDANNOTATIONS_URL);
-        RequestPatternBuilder requestPatternBuilder = getRequestedFor(urlPathEqualTo(url));
-                                                    requestPatternBuilder.withQueryParam("param", equalTo(String.valueOf(param)));
-                                                            verify(times, requestPatternBuilder);
-    }
-
-    
-    public void verifyResourceWithParamAndAnnotationsNoInteraction(java.lang.String param) {
-        String url = String.format(RESOURCEWITHPARAMANDANNOTATIONS_URL);
-        RequestPatternBuilder requestPatternBuilder = getRequestedFor(urlPathEqualTo(url));
-                                                    requestPatternBuilder.withQueryParam("param", equalTo(String.valueOf(param)));
-                                                            verify(NEVER, requestPatternBuilder);
-    }
-
-        public void verifyResourceWithParamAndAnnotationsNoInteraction() {
-        String url = String.format(RESOURCEWITHPARAMANDANNOTATIONS_URL);
         verify(NEVER, getRequestedFor(urlPathEqualTo(url)));
     }
     
@@ -207,6 +207,7 @@ public class JavaGetRestControllerStub {
         return sb.toString();
     }
 }
+
 
 
 

--- a/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/multiple/SimplePostPutRestControllerIT.kt
+++ b/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/multiple/SimplePostPutRestControllerIT.kt
@@ -1,0 +1,38 @@
+package com.lsdconsulting.stub.integration.multiple
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.tomakehurst.wiremock.client.VerificationException
+import com.lsdconsulting.stub.integration.BaseRestControllerIT
+import com.lsdconsulting.stub.integration.MULTIPLE_METHOD_CONTROLLER_URL
+import com.lsdconsulting.stub.integration.controller.multiple.SimplePostPutRestControllerStub
+import com.lsdconsulting.stub.integration.model.GreetingResponse
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.hamcrest.Matchers.notNullValue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpStatus.OK
+
+class SimplePostPutRestControllerIT : BaseRestControllerIT() {
+    private val underTest = SimplePostPutRestControllerStub(ObjectMapper())
+
+    @Test
+    fun `should handle post mapping with no request body`() {
+        underTest.verifyPostPutResourceWitNoRequestBodyNoInteraction()
+        underTest.postPutResourceWitNoRequestBody(GreetingResponse(name = name))
+
+        val response = restTemplate.postForEntity(
+            "$MULTIPLE_METHOD_CONTROLLER_URL/postPutResource",
+            HttpEntity(""),
+            GreetingResponse::class.java
+        )
+
+        assertThat(response.body, notNullValue())
+        assertThat(response.body?.name, `is`(name))
+        underTest.verifyPostPutResourceWitNoRequestBody(1)
+        underTest.verifyPostPutResourceWitNoRequestBody()
+        assertThat(response.statusCode, `is`(OK))
+        assertThrows<VerificationException> { underTest.verifyPostPutResourceWitNoRequestBodyNoInteraction() }
+    }
+}

--- a/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/multiple/SimplePostPutRestControllerIT.kt
+++ b/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/multiple/SimplePostPutRestControllerIT.kt
@@ -11,8 +11,10 @@ import org.hamcrest.Matchers.`is`
 import org.hamcrest.Matchers.notNullValue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.springframework.http.HttpEntity
+import org.springframework.http.*
+import org.springframework.http.HttpMethod.PUT
 import org.springframework.http.HttpStatus.OK
+
 
 class SimplePostPutRestControllerIT : BaseRestControllerIT() {
     private val underTest = SimplePostPutRestControllerStub(ObjectMapper())
@@ -24,6 +26,25 @@ class SimplePostPutRestControllerIT : BaseRestControllerIT() {
 
         val response = restTemplate.postForEntity(
             "$MULTIPLE_METHOD_CONTROLLER_URL/postPutResource",
+            HttpEntity(""),
+            GreetingResponse::class.java
+        )
+
+        assertThat(response.body, notNullValue())
+        assertThat(response.body?.name, `is`(name))
+        underTest.verifyPostPutResourceWitNoRequestBody(1)
+        underTest.verifyPostPutResourceWitNoRequestBody()
+        assertThat(response.statusCode, `is`(OK))
+        assertThrows<VerificationException> { underTest.verifyPostPutResourceWitNoRequestBodyNoInteraction() }
+    }
+
+    @Test
+    fun `should handle put mapping with no request body`() {
+        underTest.verifyPostPutResourceWitNoRequestBodyNoInteraction()
+        underTest.postPutResourceWitNoRequestBody(GreetingResponse(name = name))
+
+        val response = restTemplate.exchange(
+            "$MULTIPLE_METHOD_CONTROLLER_URL/postPutResource", PUT,
             HttpEntity(""),
             GreetingResponse::class.java
         )

--- a/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/multiple/SimplePostPutRestControllerIT.kt
+++ b/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/multiple/SimplePostPutRestControllerIT.kt
@@ -11,7 +11,7 @@ import org.hamcrest.Matchers.`is`
 import org.hamcrest.Matchers.notNullValue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.springframework.http.*
+import org.springframework.http.HttpEntity
 import org.springframework.http.HttpMethod.PUT
 import org.springframework.http.HttpStatus.OK
 
@@ -21,8 +21,8 @@ class SimplePostPutRestControllerIT : BaseRestControllerIT() {
 
     @Test
     fun `should handle post mapping with no request body`() {
-        underTest.verifyPostPutResourceWitNoRequestBodyNoInteraction()
-        underTest.postPutResourceWitNoRequestBody(GreetingResponse(name = name))
+        underTest.verifyPostPutResourceWitNoRequestBodyNoInteraction_POST()
+        underTest.postPutResourceWitNoRequestBody_POST(GreetingResponse(name = name))
 
         val response = restTemplate.postForEntity(
             "$MULTIPLE_METHOD_CONTROLLER_URL/postPutResource",
@@ -32,16 +32,16 @@ class SimplePostPutRestControllerIT : BaseRestControllerIT() {
 
         assertThat(response.body, notNullValue())
         assertThat(response.body?.name, `is`(name))
-        underTest.verifyPostPutResourceWitNoRequestBody(1)
-        underTest.verifyPostPutResourceWitNoRequestBody()
+        underTest.verifyPostPutResourceWitNoRequestBody_POST(1)
+        underTest.verifyPostPutResourceWitNoRequestBody_POST()
         assertThat(response.statusCode, `is`(OK))
-        assertThrows<VerificationException> { underTest.verifyPostPutResourceWitNoRequestBodyNoInteraction() }
+        assertThrows<VerificationException> { underTest.verifyPostPutResourceWitNoRequestBodyNoInteraction_POST() }
     }
 
     @Test
     fun `should handle put mapping with no request body`() {
-        underTest.verifyPostPutResourceWitNoRequestBodyNoInteraction()
-        underTest.postPutResourceWitNoRequestBody(GreetingResponse(name = name))
+        underTest.verifyPostPutResourceWitNoRequestBodyNoInteraction_PUT()
+        underTest.postPutResourceWitNoRequestBody_PUT(GreetingResponse(name = name))
 
         val response = restTemplate.exchange(
             "$MULTIPLE_METHOD_CONTROLLER_URL/postPutResource", PUT,
@@ -51,9 +51,9 @@ class SimplePostPutRestControllerIT : BaseRestControllerIT() {
 
         assertThat(response.body, notNullValue())
         assertThat(response.body?.name, `is`(name))
-        underTest.verifyPostPutResourceWitNoRequestBody(1)
-        underTest.verifyPostPutResourceWitNoRequestBody()
+        underTest.verifyPostPutResourceWitNoRequestBody_PUT(1)
+        underTest.verifyPostPutResourceWitNoRequestBody_PUT()
         assertThat(response.statusCode, `is`(OK))
-        assertThrows<VerificationException> { underTest.verifyPostPutResourceWitNoRequestBodyNoInteraction() }
+        assertThrows<VerificationException> { underTest.verifyPostPutResourceWitNoRequestBodyNoInteraction_PUT() }
     }
 }

--- a/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/post/JavaPostRestControllerIT.should remove unwanted annotations from any arguments.approved
+++ b/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/post/JavaPostRestControllerIT.should remove unwanted annotations from any arguments.approved
@@ -33,7 +33,7 @@ public class JavaPostRestControllerStub {
 
 
     public static final String RESOURCEWITHBODYANDANNOTATIONS_URL = "/postController/resourceWithBodyAndAnnotations";
-
+    
     public void resourceWithBodyAndAnnotations(com.lsdconsulting.stub.integration.model.GreetingResponse response) {
         String url = String.format(RESOURCEWITHBODYANDANNOTATIONS_URL);
                     MappingBuilder mappingBuilder = post(urlPathEqualTo(url));
@@ -81,7 +81,7 @@ public class JavaPostRestControllerStub {
         verify(NEVER, postRequestedFor(urlPathEqualTo(url)));
     }
         public static final String RESOURCEWITHBODYANDANNOTATIONSONPATHVARIABLES_URL = "/postController/resourceWithBodyAndAnnotationsOnPathVariables/%s";
-
+    
     public void resourceWithBodyAndAnnotationsOnPathVariables(com.lsdconsulting.stub.integration.model.GreetingResponse response, java.lang.String param) {
         String url = String.format(RESOURCEWITHBODYANDANNOTATIONSONPATHVARIABLES_URL, param );
                     MappingBuilder mappingBuilder = post(urlPathEqualTo(url));
@@ -149,6 +149,7 @@ public class JavaPostRestControllerStub {
     }
 
 }
+
 
 
 

--- a/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/post/SimplePostRestControllerIT.kt
+++ b/generator-integration-test/src/test/kotlin/com/lsdconsulting/stub/integration/post/SimplePostRestControllerIT.kt
@@ -21,7 +21,6 @@ class SimplePostRestControllerIT : BaseRestControllerIT() {
     @Test
     fun `should handle post mapping with no request body`() {
         underTest.verifyResourceWithNoBodyNoInteraction()
-        underTest.verifyResourceWithNoBodyNoInteraction()
         underTest.resourceWithNoBody(GreetingResponse(name = name))
 
         val response = restTemplate.postForEntity(
@@ -35,7 +34,6 @@ class SimplePostRestControllerIT : BaseRestControllerIT() {
         underTest.verifyResourceWithNoBody(1)
         underTest.verifyResourceWithNoBody()
         assertThat(response.statusCode, `is`(OK))
-        assertThrows<VerificationException> { underTest.verifyResourceWithNoBodyNoInteraction() }
         assertThrows<VerificationException> { underTest.verifyResourceWithNoBodyNoInteraction() }
     }
 
@@ -61,7 +59,6 @@ class SimplePostRestControllerIT : BaseRestControllerIT() {
     @Test
     fun `should handle post mapping with no request body and no response`() {
         underTest.verifyResourceWithNoBodyNoResponseNoInteraction()
-        underTest.verifyResourceWithNoBodyNoResponseNoInteraction()
         underTest.resourceWithNoBodyNoResponse()
 
         val response = restTemplate.postForEntity(
@@ -71,7 +68,6 @@ class SimplePostRestControllerIT : BaseRestControllerIT() {
         )
 
         assertThat(response.statusCode, `is`(OK))
-        assertThrows<VerificationException> { underTest.verifyResourceWithNoBodyNoResponseNoInteraction() }
         assertThrows<VerificationException> { underTest.verifyResourceWithNoBodyNoResponseNoInteraction() }
     }
 }

--- a/generator/src/main/kotlin/io/lsdconsulting/stub/handler/MethodMappingAnnotationHandler.kt
+++ b/generator/src/main/kotlin/io/lsdconsulting/stub/handler/MethodMappingAnnotationHandler.kt
@@ -17,8 +17,6 @@ class MethodMappingAnnotationHandler {
     ) {
         val methodModelKey = element.toString()
         val methodName = element.simpleName.toString()
-        println("element.enclosingElement.toString()=${element.enclosingElement}")
-        println("methodModelKey=${methodModelKey}")
         val controllerModel = model.getControllerModel(element.enclosingElement.toString())
         val resourceModel = controllerModel.getResourceModel(methodModelKey).getOrPut(httpMethod) { ResourceModel() }
         resourceModel.subResource = subResource(path, value)

--- a/generator/src/main/kotlin/io/lsdconsulting/stub/handler/MethodMappingAnnotationHandler.kt
+++ b/generator/src/main/kotlin/io/lsdconsulting/stub/handler/MethodMappingAnnotationHandler.kt
@@ -1,6 +1,7 @@
 package io.lsdconsulting.stub.handler
 
 import io.lsdconsulting.stub.model.Model
+import io.lsdconsulting.stub.model.ResourceModel
 import org.apache.commons.lang3.StringUtils.capitalize
 import org.springframework.http.HttpMethod
 import javax.lang.model.element.Element
@@ -16,11 +17,13 @@ class MethodMappingAnnotationHandler {
     ) {
         val methodModelKey = element.toString()
         val methodName = element.simpleName.toString()
+        println("element.enclosingElement.toString()=${element.enclosingElement}")
+        println("methodModelKey=${methodModelKey}")
         val controllerModel = model.getControllerModel(element.enclosingElement.toString())
-        controllerModel.getResourceModel(methodModelKey).subResource = subResource(path, value)
-        controllerModel.getResourceModel(methodModelKey).httpMethod = httpMethod
-        controllerModel.getResourceModel(methodModelKey).methodName = capitalize(methodName)
-        controllerModel.getResourceModel(methodModelKey).responseType = responseType
+        val resourceModel = controllerModel.getResourceModel(methodModelKey).getOrPut(httpMethod) { ResourceModel() }
+        resourceModel.subResource = subResource(path, value)
+        resourceModel.methodName = capitalize(methodName)
+        resourceModel.responseType = responseType
     }
 
     private fun subResource(path: Array<String>, value: Array<String>) =

--- a/generator/src/main/kotlin/io/lsdconsulting/stub/model/ControllerModel.kt
+++ b/generator/src/main/kotlin/io/lsdconsulting/stub/model/ControllerModel.kt
@@ -24,7 +24,6 @@ data class ControllerModel(
 }
 
 data class ResourceModel(
-//    var httpMethod: HttpMethod? = null,
     var methodName: String? = null, // TODO Rename to `resourceMethodName`
     var responseType: String? = null,
     var responseStatus: Int? = null,

--- a/generator/src/main/kotlin/io/lsdconsulting/stub/model/ControllerModel.kt
+++ b/generator/src/main/kotlin/io/lsdconsulting/stub/model/ControllerModel.kt
@@ -3,6 +3,7 @@ package io.lsdconsulting.stub.model
 import org.springframework.http.HttpMethod
 
 data class Model(
+    // Class name to ControllerModel
     val controllers: MutableMap<String, ControllerModel> = mutableMapOf(),
 ) {
     fun getControllerModel(name: String): ControllerModel = controllers.getOrPut(name) {ControllerModel()}
@@ -14,14 +15,15 @@ data class ControllerModel(
     var stubClassName: String? = null,
     var rootResource: String? = null,
     var responseStatus: Int? = null,
-    val resources: MutableMap<String, ResourceModel> = mutableMapOf(),
+    // Class method name to map of HttpMethod to ResourceModel
+    val resources: MutableMap<String, MutableMap<HttpMethod, ResourceModel>> = mutableMapOf(),
     var containsDateTimeFormat: Boolean = false
 ) {
-    fun getResourceModel(name: String): ResourceModel = resources.getOrPut(name) {ResourceModel()}
+    fun getResourceModel(name: String): MutableMap<HttpMethod, ResourceModel> = resources.getOrPut(name) {mutableMapOf()}
 }
 
 data class ResourceModel(
-    var httpMethod: HttpMethod? = null,
+//    var httpMethod: HttpMethod? = null,
     var methodName: String? = null,
     var responseType: String? = null,
     var responseStatus: Int? = null,
@@ -53,8 +55,7 @@ data class ArgumentModel(
     var iterable: Boolean = false,
     var optional: Boolean = false,
     var dateTimeFormatAnnotation: DateTimeFormatAnnotation? = null,
-) {
-}
+)
 
 data class DateTimeFormatAnnotation(
     val iso: String?,

--- a/generator/src/main/kotlin/io/lsdconsulting/stub/model/ControllerModel.kt
+++ b/generator/src/main/kotlin/io/lsdconsulting/stub/model/ControllerModel.kt
@@ -25,7 +25,7 @@ data class ControllerModel(
 
 data class ResourceModel(
 //    var httpMethod: HttpMethod? = null,
-    var methodName: String? = null,
+    var methodName: String? = null, // TODO Rename to `resourceMethodName`
     var responseType: String? = null,
     var responseStatus: Int? = null,
     var subResource: String? = null,

--- a/generator/src/main/kotlin/io/lsdconsulting/stub/model/ControllerModel.kt
+++ b/generator/src/main/kotlin/io/lsdconsulting/stub/model/ControllerModel.kt
@@ -3,7 +3,7 @@ package io.lsdconsulting.stub.model
 import org.springframework.http.HttpMethod
 
 data class Model(
-    // Class name to ControllerModel
+    // Controller class name to ControllerModel
     val controllers: MutableMap<String, ControllerModel> = mutableMapOf(),
 ) {
     fun getControllerModel(name: String): ControllerModel = controllers.getOrPut(name) {ControllerModel()}
@@ -15,7 +15,7 @@ data class ControllerModel(
     var stubClassName: String? = null,
     var rootResource: String? = null,
     var responseStatus: Int? = null,
-    // Class method name to map of HttpMethod to ResourceModel
+    // Annotated method name to map of HttpMethod to ResourceModel
     val resources: MutableMap<String, MutableMap<HttpMethod, ResourceModel>> = mutableMapOf(),
     var containsDateTimeFormat: Boolean = false,
     var hasMultipleHttpMethods: Boolean = false
@@ -23,8 +23,9 @@ data class ControllerModel(
     fun getResourceModel(name: String): MutableMap<HttpMethod, ResourceModel> = resources.getOrPut(name) {mutableMapOf()}
 }
 
+// TODO Rename to AnnotatedMethodModel
 data class ResourceModel(
-    var methodName: String? = null, // TODO Rename to `resourceMethodName`
+    var methodName: String? = null, // TODO Rename to `annotatedMethodName`
     var responseType: String? = null,
     var responseStatus: Int? = null,
     var subResource: String? = null,
@@ -48,6 +49,7 @@ data class ResourceModel(
     fun getRequestHeaderModel(name: String): ArgumentModel = requestHeaders.getOrPut(name) {ArgumentModel()}
 }
 
+// TODO Rename to MethodArgumentModel
 data class ArgumentModel(
     var name: String? = null,
     var headerName: String? = null,

--- a/generator/src/main/kotlin/io/lsdconsulting/stub/model/ControllerModel.kt
+++ b/generator/src/main/kotlin/io/lsdconsulting/stub/model/ControllerModel.kt
@@ -17,7 +17,8 @@ data class ControllerModel(
     var responseStatus: Int? = null,
     // Class method name to map of HttpMethod to ResourceModel
     val resources: MutableMap<String, MutableMap<HttpMethod, ResourceModel>> = mutableMapOf(),
-    var containsDateTimeFormat: Boolean = false
+    var containsDateTimeFormat: Boolean = false,
+    var hasMultipleHttpMethods: Boolean = false
 ) {
     fun getResourceModel(name: String): MutableMap<HttpMethod, ResourceModel> = resources.getOrPut(name) {mutableMapOf()}
 }

--- a/generator/src/main/kotlin/io/lsdconsulting/stub/processor/ControllerProcessor.kt
+++ b/generator/src/main/kotlin/io/lsdconsulting/stub/processor/ControllerProcessor.kt
@@ -131,7 +131,8 @@ class ControllerProcessor : AbstractProcessor() {
                                 model = model,
                                 path = path,
                                 value = value,
-                                httpMethod = methods[0].asHttpMethod()
+                                httpMethod = methods[0].asHttpMethod(),
+                                responseType = element.asType().toString().retrieveResponseType()?.removeResponseEntity()
                             )
                         }
                     }

--- a/generator/src/main/kotlin/io/lsdconsulting/stub/processor/ControllerProcessor.kt
+++ b/generator/src/main/kotlin/io/lsdconsulting/stub/processor/ControllerProcessor.kt
@@ -15,8 +15,7 @@ import org.springframework.web.bind.annotation.*
 import javax.annotation.processing.*
 import javax.lang.model.SourceVersion.RELEASE_17
 import javax.lang.model.element.Element
-import javax.lang.model.element.ElementKind
-import javax.lang.model.element.ElementKind.*
+import javax.lang.model.element.ElementKind.CLASS
 import javax.lang.model.element.TypeElement
 import javax.tools.Diagnostic.Kind.NOTE
 
@@ -64,174 +63,168 @@ class ControllerProcessor : AbstractProcessor() {
         if (stubAnnotations.isNotEmpty()) {
             messager.printMessage(NOTE, "Analysing source code for WireMock stubs")
         }
-        val annotatedClasses = stubAnnotations.flatMap { roundEnv.getElementsAnnotatedWith(it) }
+        val generateWireMockStubAnnotatedClasses = stubAnnotations.flatMap { roundEnv.getElementsAnnotatedWith(it) }
 
-        // Collect all elements first
-        val allElements = annotations.flatMap { annotation ->
-            roundEnv.getElementsAnnotatedWith(annotation)
-                .filter(elementsBelongingToAnnotatedClasses(annotatedClasses))
-        }
+        val allSortedElements =
+            collectAllElements(annotations, roundEnv, generateWireMockStubAnnotatedClasses).sortedBy { it.kind.order() }
 
-        // Sort once
-        val sortedElements = allElements.sortedBy { getElementOrder(it.kind) }
-
-            sortedElements.forEach { element: Element ->
-                    element.getAnnotation(RestController::class.java)?.let {
-                        val controllerModel = model.getControllerModel(element.toString())
-                        restControllerAnnotationHandler.handle(element, controllerModel)
+        allSortedElements.forEach { element: Element ->
+            element.getAnnotation(RestController::class.java)?.let {
+                val controllerModel = model.getControllerModel(element.toString())
+                restControllerAnnotationHandler.handle(element, controllerModel)
+            }
+            element.getAnnotation(GetMapping::class.java)?.let {
+                methodMappingAnnotationHandler.handle(
+                    element = element,
+                    model = model,
+                    path = it.path,
+                    value = it.value,
+                    httpMethod = GET,
+                    responseType = element.asType().toString().retrieveResponseType()?.removeResponseEntity()
+                )
+            }
+            element.getAnnotation(PostMapping::class.java)?.let {
+                methodMappingAnnotationHandler.handle(
+                    element = element,
+                    model = model,
+                    path = it.path,
+                    value = it.value,
+                    httpMethod = POST,
+                    responseType = element.asType().toString().retrieveResponseType()?.removeResponseEntity()
+                )
+            }
+            element.getAnnotation(PutMapping::class.java)?.let {
+                methodMappingAnnotationHandler.handle(
+                    element = element,
+                    model = model,
+                    path = it.path,
+                    value = it.value,
+                    httpMethod = PUT
+                )
+            }
+            element.getAnnotation(DeleteMapping::class.java)?.let {
+                methodMappingAnnotationHandler.handle(
+                    element = element,
+                    model = model,
+                    path = it.path,
+                    value = it.value,
+                    httpMethod = DELETE
+                )
+            }
+            element.getAnnotation(RequestMapping::class.java)?.let {
+                val path: Array<String> = it.path
+                val value: Array<String> = it.value
+                if (element.kind == CLASS) {
+                    val controllerModel = model.getControllerModel(element.toString())
+                    if (path.isNotEmpty()) {
+                        controllerModel.rootResource = path[0]
+                    } else if (value.isNotEmpty()) {
+                        controllerModel.rootResource = value[0]
                     }
-                    element.getAnnotation(GetMapping::class.java)?.let {
+                } else {
+                    val methods: Array<RequestMethod> = it.method
+                    methods.forEach { method ->
                         methodMappingAnnotationHandler.handle(
                             element = element,
                             model = model,
-                            path = it.path,
-                            value = it.value,
-                            httpMethod = GET,
-                            responseType = element.asType().toString().retrieveResponseType()?.removeResponseEntity()
+                            path = path,
+                            value = value,
+                            httpMethod = method.asHttpMethod(),
+                            responseType = element.asType().toString().retrieveResponseType()
+                                ?.removeResponseEntity()
                         )
-                    }
-                    element.getAnnotation(PostMapping::class.java)?.let {
-                        methodMappingAnnotationHandler.handle(
-                            element = element,
-                            model = model,
-                            path = it.path,
-                            value = it.value,
-                            httpMethod = POST,
-                            responseType = element.asType().toString().retrieveResponseType()?.removeResponseEntity()
-                        )
-                    }
-                    element.getAnnotation(PutMapping::class.java)?.let {
-                        methodMappingAnnotationHandler.handle(
-                            element = element,
-                            model = model,
-                            path = it.path,
-                            value = it.value,
-                            httpMethod = PUT
-                        )
-                    }
-                    element.getAnnotation(DeleteMapping::class.java)?.let {
-                        methodMappingAnnotationHandler.handle(
-                            element = element,
-                            model = model,
-                            path = it.path,
-                            value = it.value,
-                            httpMethod = DELETE
-                        )
-                    }
-                    element.getAnnotation(RequestMapping::class.java)?.let {
-                        val path: Array<String> = it.path
-                        val value: Array<String> = it.value
-                        if (element.kind == CLASS) {
-                            val controllerModel = model.getControllerModel(element.toString())
-                            if (path.isNotEmpty()) {
-                                controllerModel.rootResource = path[0]
-                            } else if (value.isNotEmpty()) {
-                                controllerModel.rootResource = value[0]
-                            }
-                        } else {
-                            val methods: Array<RequestMethod> = it.method
-                            methods.forEach { method ->
-                                methodMappingAnnotationHandler.handle(
-                                    element = element,
-                                    model = model,
-                                    path = path,
-                                    value = value,
-                                    httpMethod = method.asHttpMethod(),
-                                    responseType = element.asType().toString().retrieveResponseType()
-                                        ?.removeResponseEntity()
-                                )
-                            }
-                        }
-                    }
-                    element.getAnnotation(ResponseStatus::class.java)?.let {
-                        val httpStatus: HttpStatus =
-                            if (it.code != INTERNAL_SERVER_ERROR) it.code
-                            else it.value
-                        if (element.kind == CLASS) {
-                            val controllerModel = model.getControllerModel(element.toString())
-                            controllerModel.responseStatus = httpStatus.value()
-                        } else {
-                            val methodModelKey = element.toString()
-                            val controllerModel = model.getControllerModel(element.enclosingElement.toString())
-                            controllerModel.getResourceModel(methodModelKey).values
-                                .forEach { resourceModel -> resourceModel.responseStatus = httpStatus.value() }
-                        }
-                    }
-                    element.getAnnotation(RequestParam::class.java)?.let {
-                        val argumentName = firstNotNull(it.name, it.value, element.simpleName.toString())
-                        val methodName = element.enclosingElement.toString()
-                        val argumentType = element.retrieveArgumentType().replacePrimitive()
-                        val controllerModel =
-                            model.getControllerModel(element.enclosingElement.enclosingElement.toString())
-                        controllerModel.getResourceModel(methodName).values.forEach { resourceModel ->
-                            resourceModel.getRequestParamModel(argumentName).type = argumentType
-                            resourceModel.getRequestParamModel(argumentName).name = argumentName
-                            resourceModel.getRequestParamModel(argumentName).optional = !it.required
-                            if ("java.util.Set<(.*)>|java.util.List<(.*)>|java.lang.String\\[]".toRegex()
-                                    .containsMatchIn(argumentType)
-                            ) {
-                                if (!resourceModel.hasOptionalMultiValueRequestParams) { // So that other non-optional multi value query parameters don't overwrite this value
-                                    resourceModel.hasOptionalMultiValueRequestParams = !it.required
-                                }
-                                resourceModel.getRequestParamModel(argumentName).iterable = true
-                            }
-                        }
-                    }
-                    element.getAnnotation(PathVariable::class.java)?.let {
-                        val argumentName = firstNotNull(it.name, it.value, element.simpleName.toString())
-                        val methodName = element.enclosingElement.toString()
-                        val argumentType = element.retrieveArgumentType()
-                        val controllerModel =
-                            model.getControllerModel(element.enclosingElement.enclosingElement.toString())
-                        controllerModel.getResourceModel(methodName).values.forEach { resourceModel ->
-                            resourceModel.urlHasPathVariable = true
-                            resourceModel.getPathVariableModel(argumentName).type = argumentType
-                            resourceModel.getPathVariableModel(argumentName).name = argumentName
-                        }
-                    }
-                    element.getAnnotation(RequestBody::class.java)?.let {
-                        val methodName = element.enclosingElement.toString()
-                        val argumentName = element.simpleName.toString()
-                        val argumentType = element.retrieveArgumentType()
-                        val controllerModel =
-                            model.getControllerModel(element.enclosingElement.enclosingElement.toString())
-                        val requestBody = ArgumentModel(type = argumentType, name = argumentName)
-                        controllerModel.getResourceModel(methodName).values.forEach { resourceModel ->
-                            resourceModel.requestBody = requestBody
-                        }
-                    }
-                    element.getAnnotation(DateTimeFormat::class.java)?.let {
-                        val methodName = element.enclosingElement.toString()
-                        val argumentName = element.simpleName.toString()
-                        model
-                            .getControllerModel(element.enclosingElement.enclosingElement.toString())
-                            .getResourceModel(methodName)
-                            .values.forEach { resourceModel ->
-                                resourceModel.getRequestParamModel(argumentName).dateTimeFormatAnnotation =
-                                    DateTimeFormatAnnotation(
-                                        iso = it.iso.name,
-                                        fallbackPatterns = it.fallbackPatterns,
-                                        pattern = it.pattern,
-                                        style = it.style,
-                                        clazz = element.retrieveArgumentType().retrieveGeneric()
-                                    )
-                            }
-                    }
-                    element.getAnnotation(RequestHeader::class.java)?.let {
-                        val argumentName = firstNotNull(element.simpleName.toString())
-                        val headerName = firstNotNull(it.name, it.value, element.simpleName.toString())
-                        val methodName = element.enclosingElement.toString()
-                        val argumentType = element.retrieveArgumentType()
-                        val controllerModel =
-                            model.getControllerModel(element.enclosingElement.enclosingElement.toString())
-                        controllerModel.getResourceModel(methodName).values.forEach { resourceModel ->
-                            resourceModel.getRequestHeaderModel(argumentName).type = argumentType
-                            resourceModel.getRequestHeaderModel(argumentName).name = argumentName
-                            resourceModel.getRequestHeaderModel(argumentName).headerName = headerName
-                            resourceModel.getRequestHeaderModel(argumentName).optional = !it.required
-                        }
                     }
                 }
+            }
+            element.getAnnotation(ResponseStatus::class.java)?.let {
+                val httpStatus: HttpStatus =
+                    if (it.code != INTERNAL_SERVER_ERROR) it.code
+                    else it.value
+                if (element.kind == CLASS) {
+                    val controllerModel = model.getControllerModel(element.toString())
+                    controllerModel.responseStatus = httpStatus.value()
+                } else {
+                    val methodModelKey = element.toString()
+                    val controllerModel = model.getControllerModel(element.enclosingElement.toString())
+                    controllerModel.getResourceModel(methodModelKey).values
+                        .forEach { resourceModel -> resourceModel.responseStatus = httpStatus.value() }
+                }
+            }
+            element.getAnnotation(RequestParam::class.java)?.let {
+                val argumentName = firstNotNull(it.name, it.value, element.simpleName.toString())
+                val methodName = element.enclosingElement.toString()
+                val argumentType = element.retrieveArgumentType().replacePrimitive()
+                val controllerModel =
+                    model.getControllerModel(element.enclosingElement.enclosingElement.toString())
+                controllerModel.getResourceModel(methodName).values.forEach { resourceModel ->
+                    resourceModel.getRequestParamModel(argumentName).type = argumentType
+                    resourceModel.getRequestParamModel(argumentName).name = argumentName
+                    resourceModel.getRequestParamModel(argumentName).optional = !it.required
+                    if ("java.util.Set<(.*)>|java.util.List<(.*)>|java.lang.String\\[]".toRegex()
+                            .containsMatchIn(argumentType)
+                    ) {
+                        if (!resourceModel.hasOptionalMultiValueRequestParams) { // So that other non-optional multi value query parameters don't overwrite this value
+                            resourceModel.hasOptionalMultiValueRequestParams = !it.required
+                        }
+                        resourceModel.getRequestParamModel(argumentName).iterable = true
+                    }
+                }
+            }
+            element.getAnnotation(PathVariable::class.java)?.let {
+                val argumentName = firstNotNull(it.name, it.value, element.simpleName.toString())
+                val methodName = element.enclosingElement.toString()
+                val argumentType = element.retrieveArgumentType()
+                val controllerModel =
+                    model.getControllerModel(element.enclosingElement.enclosingElement.toString())
+                controllerModel.getResourceModel(methodName).values.forEach { resourceModel ->
+                    resourceModel.urlHasPathVariable = true
+                    resourceModel.getPathVariableModel(argumentName).type = argumentType
+                    resourceModel.getPathVariableModel(argumentName).name = argumentName
+                }
+            }
+            element.getAnnotation(RequestBody::class.java)?.let {
+                val methodName = element.enclosingElement.toString()
+                val argumentName = element.simpleName.toString()
+                val argumentType = element.retrieveArgumentType()
+                val controllerModel =
+                    model.getControllerModel(element.enclosingElement.enclosingElement.toString())
+                val requestBody = ArgumentModel(type = argumentType, name = argumentName)
+                controllerModel.getResourceModel(methodName).values.forEach { resourceModel ->
+                    resourceModel.requestBody = requestBody
+                }
+            }
+            element.getAnnotation(DateTimeFormat::class.java)?.let {
+                val methodName = element.enclosingElement.toString()
+                val argumentName = element.simpleName.toString()
+                model
+                    .getControllerModel(element.enclosingElement.enclosingElement.toString())
+                    .getResourceModel(methodName)
+                    .values.forEach { resourceModel ->
+                        resourceModel.getRequestParamModel(argumentName).dateTimeFormatAnnotation =
+                            DateTimeFormatAnnotation(
+                                iso = it.iso.name,
+                                fallbackPatterns = it.fallbackPatterns,
+                                pattern = it.pattern,
+                                style = it.style,
+                                clazz = element.retrieveArgumentType().retrieveGeneric()
+                            )
+                    }
+            }
+            element.getAnnotation(RequestHeader::class.java)?.let {
+                val argumentName = firstNotNull(element.simpleName.toString())
+                val headerName = firstNotNull(it.name, it.value, element.simpleName.toString())
+                val methodName = element.enclosingElement.toString()
+                val argumentType = element.retrieveArgumentType()
+                val controllerModel =
+                    model.getControllerModel(element.enclosingElement.enclosingElement.toString())
+                controllerModel.getResourceModel(methodName).values.forEach { resourceModel ->
+                    resourceModel.getRequestHeaderModel(argumentName).type = argumentType
+                    resourceModel.getRequestHeaderModel(argumentName).name = argumentName
+                    resourceModel.getRequestHeaderModel(argumentName).headerName = headerName
+                    resourceModel.getRequestHeaderModel(argumentName).optional = !it.required
+                }
+            }
+        }
 
         postProcessor.update(model)
 
@@ -246,6 +239,15 @@ class ControllerProcessor : AbstractProcessor() {
         return true
     }
 
+    private fun collectAllElements(
+        annotations: MutableSet<out TypeElement>,
+        roundEnv: RoundEnvironment,
+        generateWireMockStubAnnotatedClasses: List<Element>
+    ) = annotations.flatMap { annotation ->
+        roundEnv.getElementsAnnotatedWith(annotation)
+            .filter(elementsBelongingToAnnotatedClasses(generateWireMockStubAnnotatedClasses))
+    }
+
     private fun firstNotNull(vararg elements: String) = elements.first { it.isNotEmpty() }
 
     private fun elementsBelongingToAnnotatedClasses(annotatedClasses: List<Element>): (Element) -> Boolean =
@@ -254,13 +256,5 @@ class ControllerProcessor : AbstractProcessor() {
                     annotatedClasses.contains(it.enclosingElement) or
                     annotatedClasses.contains(it.enclosingElement.enclosingElement) or
                     annotatedClasses.contains(it.enclosingElement.enclosingElement.enclosingElement)
-        }
-
-    private fun getElementOrder(kind: ElementKind) =
-        when (kind) {
-            CLASS -> 1
-            METHOD -> 2
-            PARAMETER -> 3
-            else -> 4
         }
 }

--- a/generator/src/main/kotlin/io/lsdconsulting/stub/processor/PostProcessor.kt
+++ b/generator/src/main/kotlin/io/lsdconsulting/stub/processor/PostProcessor.kt
@@ -43,10 +43,7 @@ class PostProcessor {
 
     private fun setHasMultipleHttpMethods(controllerModel: ControllerModel) =
         controllerModel.resources.values.forEach { resource ->
-            println("resource.value=" + resource.values)
-            println("resource.value.size=" + resource.values.size)
             if (resource.values.isNotEmpty() && resource.values.size > 1) {
-                println("Setting hasMultipleHttpMethods = true for controllerModel.stubClassName=" + controllerModel.stubClassName)
                 controllerModel.hasMultipleHttpMethods = true
                 return
             }

--- a/generator/src/main/kotlin/io/lsdconsulting/stub/processor/PostProcessor.kt
+++ b/generator/src/main/kotlin/io/lsdconsulting/stub/processor/PostProcessor.kt
@@ -8,6 +8,7 @@ class PostProcessor {
         model.controllers.values.forEach { controllerModel ->
             updateResponseStatusOnResources(controllerModel)
             setContainsDateTimeFormat(controllerModel)
+            setHasMultipleHttpMethods(controllerModel)
             controllerModel.resources.values.forEach { resource ->
                 resource.values.forEach { annotatedMethod ->
                     if (annotatedMethod.urlHasPathVariable) {
@@ -37,6 +38,17 @@ class PostProcessor {
                 resource.values.forEach {
                     it.responseStatus = it.responseStatus ?: controllerModel.responseStatus
                 }
+            }
+        }
+
+    private fun setHasMultipleHttpMethods(controllerModel: ControllerModel) =
+        controllerModel.resources.values.forEach { resource ->
+            println("resource.value=" + resource.values)
+            println("resource.value.size=" + resource.values.size)
+            if (resource.values.isNotEmpty() && resource.values.size > 1) {
+                println("Setting hasMultipleHttpMethods = true for controllerModel.stubClassName=" + controllerModel.stubClassName)
+                controllerModel.hasMultipleHttpMethods = true
+                return
             }
         }
 

--- a/generator/src/main/kotlin/io/lsdconsulting/stub/processor/PostProcessor.kt
+++ b/generator/src/main/kotlin/io/lsdconsulting/stub/processor/PostProcessor.kt
@@ -8,41 +8,51 @@ class PostProcessor {
         model.controllers.values.forEach { controllerModel ->
             updateResponseStatusOnResources(controllerModel)
             setContainsDateTimeFormat(controllerModel)
-            controllerModel.resources.values.forEach { annotatedMethod ->
-                if (annotatedMethod.urlHasPathVariable) {
-                    annotatedMethod.pathVariables.values.forEach { pathVariable ->
-                        annotatedMethod.subResource =
-                            annotatedMethod.subResource?.replace("{${pathVariable.name}}", "%s")
+            controllerModel.resources.values.forEach { resource ->
+                resource.values.forEach { annotatedMethod ->
+                    if (annotatedMethod.urlHasPathVariable) {
+                        annotatedMethod.pathVariables.values.forEach { pathVariable ->
+                            annotatedMethod.subResource =
+                                annotatedMethod.subResource?.replace("{${pathVariable.name}}", "%s")
+                        }
                     }
+                    annotatedMethod.stubMethodArgumentList = stubArgumentList(annotatedMethod)
+                    annotatedMethod.stubMethodArgumentListWithRequest = stubArgumentListWithRequest(annotatedMethod)
+                    annotatedMethod.stubMethodArgumentListForCustomResponse =
+                        stubArgumentListForCustomResponse(annotatedMethod)
+                    annotatedMethod.verifyMethodArgumentList = verifyArgumentList(annotatedMethod)
+                    annotatedMethod.verifyMethodArgumentListWithTimes = verifyArgumentListWithTimes(annotatedMethod)
+                    annotatedMethod.verifyMethodArgumentListWithTimesWithoutBody =
+                        verifyArgumentListWithTimesWithoutBody(annotatedMethod)
+                    annotatedMethod.verifyMethodArgumentListPathVariablesOnly = pathVariables(annotatedMethod)
+                    annotatedMethod.verifyStubCallArgumentList = verifyStubCallArgumentList(annotatedMethod)
                 }
-                annotatedMethod.stubMethodArgumentList = stubArgumentList(annotatedMethod)
-                annotatedMethod.stubMethodArgumentListWithRequest = stubArgumentListWithRequest(annotatedMethod)
-                annotatedMethod.stubMethodArgumentListForCustomResponse = stubArgumentListForCustomResponse(annotatedMethod)
-                annotatedMethod.verifyMethodArgumentList = verifyArgumentList(annotatedMethod)
-                annotatedMethod.verifyMethodArgumentListWithTimes = verifyArgumentListWithTimes(annotatedMethod)
-                annotatedMethod.verifyMethodArgumentListWithTimesWithoutBody = verifyArgumentListWithTimesWithoutBody(annotatedMethod)
-                annotatedMethod.verifyMethodArgumentListPathVariablesOnly = pathVariables(annotatedMethod)
-                annotatedMethod.verifyStubCallArgumentList = verifyStubCallArgumentList(annotatedMethod)
             }
         }
     }
 
     private fun updateResponseStatusOnResources(controllerModel: ControllerModel) =
         controllerModel.responseStatus?.let {
-            controllerModel.resources.values.forEach {
-                it.responseStatus = it.responseStatus ?: controllerModel.responseStatus
+            controllerModel.resources.values.forEach { resource ->
+                resource.values.forEach {
+                    it.responseStatus = it.responseStatus ?: controllerModel.responseStatus
+                }
             }
         }
 
     private fun setContainsDateTimeFormat(controllerModel: ControllerModel) {
-        controllerModel.resources.values.forEach {
-            val controllerContainsDateTimeFormat =
-                    it.requestParameters.values.map { argumentModel -> argumentModel.dateTimeFormatAnnotation != null }.contains(true) ||
-                    it.pathVariables.values.map { argumentModel -> argumentModel.dateTimeFormatAnnotation != null }.contains(true) ||
-                    it.requestBody?.dateTimeFormatAnnotation != null
-            if (controllerContainsDateTimeFormat) {
-                controllerModel.containsDateTimeFormat = true
-                return
+        controllerModel.resources.values.forEach { resource ->
+            resource.values.forEach {
+                val controllerContainsDateTimeFormat =
+                    it.requestParameters.values.map { argumentModel -> argumentModel.dateTimeFormatAnnotation != null }
+                        .contains(true) ||
+                            it.pathVariables.values.map { argumentModel -> argumentModel.dateTimeFormatAnnotation != null }
+                                .contains(true) ||
+                            it.requestBody?.dateTimeFormatAnnotation != null
+                if (controllerContainsDateTimeFormat) {
+                    controllerModel.containsDateTimeFormat = true
+                    return
+                }
             }
         }
     }

--- a/generator/src/main/kotlin/io/lsdconsulting/stub/processor/typeHandlerExtensions.kt
+++ b/generator/src/main/kotlin/io/lsdconsulting/stub/processor/typeHandlerExtensions.kt
@@ -1,6 +1,8 @@
 package io.lsdconsulting.stub.processor
 
 import javax.lang.model.element.Element
+import javax.lang.model.element.ElementKind
+import javax.lang.model.element.ElementKind.*
 
 fun Element.retrieveArgumentType(): String {
     var argumentType = this.asType().toString()
@@ -45,3 +47,11 @@ fun String.retrieveResponseType(): String? {
     val responseType = this.replace(Regex("\\(.*\\)"), "")
     return if (responseType.equals("void", true)) null else responseType
 }
+
+fun ElementKind.order() =
+    when (this) {
+        CLASS -> 1
+        METHOD -> 2
+        PARAMETER -> 3
+        else -> 4
+    }

--- a/generator/src/main/resources/templates/Stub.peb
+++ b/generator/src/main/resources/templates/Stub.peb
@@ -49,8 +49,9 @@ public class {{model.stubClassName}} {
 {% for map in model.getResources %}
 {% for entry in map.value %}
     {%if model.hasMultipleHttpMethods == false or model.hasMultipleHttpMethods and loop.index == 0%}
-    public static final String {{entry.value.methodName.toUpperCase()}}_URL = "{{model.rootResource}}{{entry.value.subResource}}";
+public static final String {{entry.value.methodName.toUpperCase()}}_URL = "{{model.rootResource}}{{entry.value.subResource}}";
     {% endif %}
+
     public void {{decapitaliseFirstLetterOf(entry.value.methodName)}}{{ addOptionalHttpMethodName(model, entry) }}({{ entry.value.stubMethodArgumentList | join(', ') | raw}}) {
         {{ generateUrlWithPathVariables(entry) }}
         {% if entry.value.hasOptionalMultiValueRequestParams %}

--- a/generator/src/main/resources/templates/Stub.peb
+++ b/generator/src/main/resources/templates/Stub.peb
@@ -46,56 +46,58 @@ public class {{model.stubClassName}} {
     }
 {% endif %}
 
-{% for entry in model.getResources %}
+{% for map in model.getResources %}
+{% for entry in map.value %}
+    {%if model.hasMultipleHttpMethods == false or model.hasMultipleHttpMethods and loop.index == 0%}
     public static final String {{entry.value.methodName.toUpperCase()}}_URL = "{{model.rootResource}}{{entry.value.subResource}}";
-
-    public void {{decapitaliseFirstLetterOf(entry.value.methodName)}}({{ entry.value.stubMethodArgumentList | join(', ') | raw}}) {
+    {% endif %}
+    public void {{decapitaliseFirstLetterOf(entry.value.methodName)}}{{ addOptionalHttpMethodName(model, entry) }}({{ entry.value.stubMethodArgumentList | join(', ') | raw}}) {
         {{ generateUrlWithPathVariables(entry) }}
         {% if entry.value.hasOptionalMultiValueRequestParams %}
             {{ addRequestParamsToUrl(entry) }}
-            MappingBuilder mappingBuilder = {{entry.value.httpMethod.name() | lower}}(urlEqualTo(url));
+            MappingBuilder mappingBuilder = {{entry.key.name() | lower}}(urlEqualTo(url));
             stub({% if entry.value.responseStatus is empty%}OK{% else %}{{ entry.value.responseStatus }}{% endif %}, {% if entry.value.responseType is not empty%}buildBody(response){% else %}null{% endif %}, mappingBuilder);
         {% else %}
-            MappingBuilder mappingBuilder = {{entry.value.httpMethod.name() | lower}}(urlPathEqualTo(url));
+            MappingBuilder mappingBuilder = {{entry.key.name() | lower}}(urlPathEqualTo(url));
             {{ addQueryParamsToMappingBuilder(entry) }}
             stub({% if entry.value.responseStatus is empty%}OK{% else %}{{ entry.value.responseStatus }}{% endif %}, {% if entry.value.responseType is not empty%}buildBody(response){% else %}null{% endif %}, mappingBuilder);
         {% endif %}
     }
 
-    {% if entry.value.requestBody != null and ["POST", "PUT"] contains entry.value.httpMethod.name() %}
-    public void {{decapitaliseFirstLetterOf(entry.value.methodName)}}({{ entry.value.stubMethodArgumentListWithRequest | join(', ') | raw}}) {
+    {% if entry.value.requestBody != null and ["POST", "PUT"] contains entry.key.name() %}
+    public void {{decapitaliseFirstLetterOf(entry.value.methodName)}}{{ addOptionalHttpMethodName(model, entry) }}({{ entry.value.stubMethodArgumentListWithRequest | join(', ') | raw}}) {
         {{ generateUrlWithPathVariables(entry) }}
         {% if entry.value.hasOptionalMultiValueRequestParams %}
             {{ addRequestParamsToUrl(entry) }}
-            MappingBuilder mappingBuilder = {{entry.value.httpMethod.name() | lower}}(urlEqualTo(url)).withRequestBody(equalToJson(buildBody({{ entry.value.requestBody.name }})));
+            MappingBuilder mappingBuilder = {{entry.key.name() | lower}}(urlEqualTo(url)).withRequestBody(equalToJson(buildBody({{ entry.value.requestBody.name }})));
             stub({% if entry.value.responseStatus is empty%}OK{% else %}{{ entry.value.responseStatus }}{% endif %}, {% if entry.value.responseType is not empty%}buildBody(response){% else %}null{% endif %}, mappingBuilder);
         {% else %}
-            MappingBuilder mappingBuilder = {{entry.value.httpMethod.name() | lower}}(urlPathEqualTo(url)).withRequestBody(equalToJson(buildBody({{ entry.value.requestBody.name }})));
+            MappingBuilder mappingBuilder = {{entry.key.name() | lower}}(urlPathEqualTo(url)).withRequestBody(equalToJson(buildBody({{ entry.value.requestBody.name }})));
             {{ addQueryParamsToMappingBuilder(entry) }}
             stub({% if entry.value.responseStatus is empty%}OK{% else %}{{ entry.value.responseStatus }}{% endif %}, {% if entry.value.responseType is not empty%}buildBody(response){% else %}null{% endif %}, mappingBuilder);
         {% endif %}
     }
     {% endif %}
 
-    public void {{decapitaliseFirstLetterOf(entry.value.methodName)}}({{ entry.value.stubMethodArgumentListForCustomResponse | join(', ') | raw}}) {
+    public void {{decapitaliseFirstLetterOf(entry.value.methodName)}}{{ addOptionalHttpMethodName(model, entry) }}({{ entry.value.stubMethodArgumentListForCustomResponse | join(', ') | raw}}) {
         {{ generateUrlWithPathVariables(entry) }}
         {% if entry.value.hasOptionalMultiValueRequestParams %}
             {{ addRequestParamsToUrl(entry) }}
-            stub(httpStatus, response, {{entry.value.httpMethod.name() | lower}}(urlEqualTo(url)));
+            stub(httpStatus, response, {{entry.key.name() | lower}}(urlEqualTo(url)));
         {% else %}
-            MappingBuilder mappingBuilder = {{entry.value.httpMethod.name() | lower}}(urlPathEqualTo(url));
+            MappingBuilder mappingBuilder = {{entry.key.name() | lower}}(urlPathEqualTo(url));
         {{ addQueryParamsToMappingBuilder(entry) }}
             stub(httpStatus, response, mappingBuilder);
         {% endif %}
     }
 
-    public void verify{{entry.value.methodName}}({{ entry.value.verifyMethodArgumentList | join(', ') | raw}}) {
-        verify{{entry.value.methodName}}({{ entry.value.verifyStubCallArgumentList | join(', ') | raw}});
+    public void verify{{entry.value.methodName}}{{ addOptionalHttpMethodName(model, entry) }}({{ entry.value.verifyMethodArgumentList | join(', ') | raw}}) {
+        verify{{entry.value.methodName}}{{ addOptionalHttpMethodName(model, entry) }}({{ entry.value.verifyStubCallArgumentList | join(', ') | raw}});
     }
 
-    public void verify{{entry.value.methodName}}({{ entry.value.verifyMethodArgumentListWithTimes | join(', ') | raw}}) {
+    public void verify{{entry.value.methodName}}{{ addOptionalHttpMethodName(model, entry) }}({{ entry.value.verifyMethodArgumentListWithTimes | join(', ') | raw}}) {
         {{ generateUrlWithPathVariables(entry) }}
-        RequestPatternBuilder requestPatternBuilder = {{entry.value.httpMethod.name() | lower}}RequestedFor(urlPathEqualTo(url));
+        RequestPatternBuilder requestPatternBuilder = {{entry.key.name() | lower}}RequestedFor(urlPathEqualTo(url));
         {{ addQueryParamsToRequestPatternBuilder(entry) }}
         {{ addRequestHeadersToRequestPatternBuilder(entry) }}
         {% if entry.value.requestBody is not empty%}
@@ -105,18 +107,18 @@ public class {{model.stubClassName}} {
     }
 
     {% if entry.value.verifyMethodArgumentListWithTimesWithoutBody != entry.value.verifyMethodArgumentListWithTimes %}
-    public void verify{{entry.value.methodName}}({{ entry.value.verifyMethodArgumentListWithTimesWithoutBody | join(', ') | raw}}) {
+    public void verify{{entry.value.methodName}}{{ addOptionalHttpMethodName(model, entry) }}({{ entry.value.verifyMethodArgumentListWithTimesWithoutBody | join(', ') | raw}}) {
         {{ generateUrlWithPathVariables(entry) }}
-        RequestPatternBuilder requestPatternBuilder = {{entry.value.httpMethod.name() | lower}}RequestedFor(urlPathEqualTo(url));
+        RequestPatternBuilder requestPatternBuilder = {{entry.key.name() | lower}}RequestedFor(urlPathEqualTo(url));
         {{ addQueryParamsToRequestPatternBuilder(entry) }}
         {{ addRequestHeadersToRequestPatternBuilder(entry) }}
         verify(times, requestPatternBuilder);
     }
     {% endif %}
 
-    public void verify{{entry.value.methodName}}NoInteraction({{ entry.value.verifyMethodArgumentList | join(', ') | raw}}) {
+    public void verify{{entry.value.methodName}}NoInteraction{{ addOptionalHttpMethodName(model, entry) }}({{ entry.value.verifyMethodArgumentList | join(', ') | raw}}) {
         {{ generateUrlWithPathVariables(entry) }}
-        RequestPatternBuilder requestPatternBuilder = {{entry.value.httpMethod.name() | lower}}RequestedFor(urlPathEqualTo(url));
+        RequestPatternBuilder requestPatternBuilder = {{entry.key.name() | lower}}RequestedFor(urlPathEqualTo(url));
         {{ addQueryParamsToRequestPatternBuilder(entry) }}
         {{ addRequestHeadersToRequestPatternBuilder(entry) }}
         {% if entry.value.requestBody is not empty%}
@@ -126,11 +128,12 @@ public class {{model.stubClassName}} {
     }
 
     {% if not entry.value.hasOptionalMultiValueRequestParams and entry.value.verifyMethodArgumentList != entry.value.verifyMethodArgumentListPathVariablesOnly %}
-    public void verify{{entry.value.methodName}}NoInteraction({{ entry.value.verifyMethodArgumentListPathVariablesOnly | join(', ') | raw}}) {
+    public void verify{{entry.value.methodName}}NoInteraction{{ addOptionalHttpMethodName(model, entry) }}({{ entry.value.verifyMethodArgumentListPathVariablesOnly | join(', ') | raw}}) {
         {{ generateUrlWithPathVariables(entry) }}
-        verify(NEVER, {{entry.value.httpMethod.name() | lower}}RequestedFor(urlPathEqualTo(url)));
+        verify(NEVER, {{entry.key.name() | lower}}RequestedFor(urlPathEqualTo(url)));
     }
     {% endif %}
+{% endfor %}
 {% endfor %}
 
     void stub(final int status, final String response, final MappingBuilder mappingBuilder) {
@@ -309,4 +312,8 @@ if ({{entry2.value.name}} != null) {
             }
         {% endif %}
     {% endfor %}
+{% endmacro %}
+
+{% macro addOptionalHttpMethodName(model, entry) %}
+{%if model.hasMultipleHttpMethods %}_{{ entry.key }}{% endif %}
 {% endmacro %}

--- a/generator/src/test/java/io/lsdconsulting/stub/handler/RestControllerAnnotationHandlerShould.java
+++ b/generator/src/test/java/io/lsdconsulting/stub/handler/RestControllerAnnotationHandlerShould.java
@@ -1,7 +1,6 @@
 package io.lsdconsulting.stub.handler;
 
 import io.lsdconsulting.stub.model.ControllerModel;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,6 +11,7 @@ import javax.lang.model.element.PackageElement;
 import javax.lang.model.util.Elements;
 import java.lang.annotation.Annotation;
 
+import static org.apache.commons.lang3.RandomStringUtils.secure;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
@@ -27,11 +27,11 @@ class RestControllerAnnotationHandlerShould {
 
     private final RestControllerAnnotationHandler underTest = new RestControllerAnnotationHandler(elementUtils);
 
-    private final String controllerBeanName = RandomStringUtils.randomAlphabetic(10);
-    private final String annotatedClassName = RandomStringUtils.randomAlphabetic(10);
-    private final String packageNameString = RandomStringUtils.randomAlphabetic(10);
-    private final String stubPackageName = RandomStringUtils.randomAlphabetic(10);
-    private final String stubClassName = RandomStringUtils.randomAlphabetic(10);
+    private final String controllerBeanName = secure().nextAlphanumeric(10);
+    private final String annotatedClassName = secure().nextAlphanumeric(10);
+    private final String packageNameString = secure().nextAlphanumeric(10);
+    private final String stubPackageName = secure().nextAlphanumeric(10);
+    private final String stubClassName = secure().nextAlphanumeric(10);
 
     private final ControllerModel model = new ControllerModel();
 

--- a/generator/src/test/java/io/lsdconsulting/stub/processor/PostProcessorShould.kt
+++ b/generator/src/test/java/io/lsdconsulting/stub/processor/PostProcessorShould.kt
@@ -10,6 +10,7 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.hasProperty
 import org.hamcrest.Matchers.`is`
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpMethod.POST
 import kotlin.random.Random
 
 internal class PostProcessorShould {
@@ -20,17 +21,19 @@ internal class PostProcessorShould {
     @Test
     fun `set response status on unannotated methods when class annotated`() {
         val controllerModel = ControllerModel(responseStatus = responseStatus)
-        controllerModel.resources["1"] = ResourceModel()
-        controllerModel.resources["2"] = ResourceModel()
-        controllerModel.resources["3"] = ResourceModel()
+        controllerModel.resources["1"] = mutableMapOf(POST to ResourceModel())
+        controllerModel.resources["2"] = mutableMapOf(POST to ResourceModel())
+        controllerModel.resources["3"] = mutableMapOf(POST to ResourceModel())
         val model = Model()
         model.controllers["someClass"] = controllerModel
 
         underTest.update(model)
 
         model.controllers.values.forEach { controller ->
-            controller.resources.values.forEach {
-                assertThat(it.responseStatus, `is`(responseStatus))
+            controller.resources.values.forEach { resource ->
+                resource.values.forEach {
+                    assertThat(it.responseStatus, `is`(responseStatus))
+                }
             }
         }
     }
@@ -41,19 +44,19 @@ internal class PostProcessorShould {
         val resourceModelWithResponseStatus = ResourceModel()
         val resourceResponseStatus = Random.nextInt()
         resourceModelWithResponseStatus.responseStatus = resourceResponseStatus
-        controllerModel.resources["1"] = resourceModelWithResponseStatus
-        controllerModel.resources["2"] = ResourceModel()
+        controllerModel.resources["1"] = mutableMapOf(POST to resourceModelWithResponseStatus)
+        controllerModel.resources["2"] = mutableMapOf(POST to ResourceModel())
         val model = Model()
         model.controllers["someClass"] = controllerModel
 
         underTest.update(model)
 
         assertThat(
-            model.controllers.values.first().resources.values,
+            model.controllers.values.first().resources.values.first().values,
             hasItem(hasProperty<ResourceModel>("responseStatus", equalTo(resourceResponseStatus)))
         )
         assertThat(
-            model.controllers.values.first().resources.values,
+            model.controllers.values.first().resources.values.first().values,
             hasItem(hasProperty<ResourceModel>("responseStatus", equalTo(responseStatus)))
         )
     }
@@ -64,8 +67,8 @@ internal class PostProcessorShould {
         val resourceModelWithResponseStatus = ResourceModel()
         val resourceResponseStatus = Random.nextInt()
         resourceModelWithResponseStatus.responseStatus = resourceResponseStatus
-        controllerModel.resources["1"] = resourceModelWithResponseStatus
-        controllerModel.resources["2"] = resourceModelWithResponseStatus
+        controllerModel.resources["1"] = mutableMapOf(POST to resourceModelWithResponseStatus)
+        controllerModel.resources["2"] = mutableMapOf(POST to resourceModelWithResponseStatus)
         val model = Model()
         model.controllers["someClass"] = controllerModel
 
@@ -90,13 +93,13 @@ internal class PostProcessorShould {
                 subResource = "/subResource/{param1}/{param2}",
                 pathVariables = mutableMapOf("1" to ArgumentModel("param1"), "2" to ArgumentModel("param2"))
             )
-        controllerModel.resources["1"] = resourceModel
+        controllerModel.resources["1"] = mutableMapOf(POST to resourceModel)
         val model = Model()
         model.controllers["someClass"] = controllerModel
 
         underTest.update(model)
 
-        assertThat(model.controllers.values.first().resources.values.first().subResource, `is`("/subResource/%s/%s"))
+        assertThat(model.controllers.values.first().resources.values.first()[POST]?.subResource, `is`("/subResource/%s/%s"))
     }
 
     @Test
@@ -107,12 +110,12 @@ internal class PostProcessorShould {
                 urlHasPathVariable = false,
                 subResource = "/subResource/{param1}/{param2}"
             )
-        controllerModel.resources["1"] = resourceModel
+        controllerModel.resources["1"] = mutableMapOf(POST to resourceModel)
         val model = Model()
         model.controllers["someClass"] = controllerModel
 
         underTest.update(model)
 
-        assertThat(model.controllers.values.first().resources.values.first().subResource, `is`("/subResource/{param1}/{param2}"))
+        assertThat(model.controllers.values.first().resources.values.first()[POST]?.subResource, `is`("/subResource/{param1}/{param2}"))
     }
 }

--- a/generator/src/test/java/io/lsdconsulting/stub/processor/PostProcessorShould.kt
+++ b/generator/src/test/java/io/lsdconsulting/stub/processor/PostProcessorShould.kt
@@ -56,7 +56,7 @@ internal class PostProcessorShould {
             hasItem(hasProperty<ResourceModel>("responseStatus", equalTo(resourceResponseStatus)))
         )
         assertThat(
-            model.controllers.values.first().resources.values.first().values,
+            model.controllers.values.first().resources.values.stream().toList()[1].values,
             hasItem(hasProperty<ResourceModel>("responseStatus", equalTo(responseStatus)))
         )
     }
@@ -75,11 +75,7 @@ internal class PostProcessorShould {
         underTest.update(model)
 
         assertThat(
-            model.controllers.values.first().resources.values,
-            hasItem(hasProperty<ResourceModel>("responseStatus", equalTo(resourceResponseStatus)))
-        )
-        assertThat(
-            model.controllers.values.first().resources.values,
+            model.controllers.values.first().resources.values.first().values,
             hasItem(hasProperty<ResourceModel>("responseStatus", equalTo(resourceResponseStatus)))
         )
     }


### PR DESCRIPTION
This change add handling of multiple HTTP methods declared by `@RequestMapping` on a method level.

The challange here was to understand the fact that because of the model change which adds a new map, the processing order of the annotations becomes important as the map has to have all the keys in place before the certain annotations are processed. Hence this:
```kotlin
    private fun getElementOrder(kind: ElementKind) =
        when (kind) {
            CLASS -> 1
            METHOD -> 2
            PARAMETER -> 3
            else -> 4
        }
```

During this work I noticed the `Stub.peg` file could be improved signmificantly through renaming the `entry` variables to whart they actually are - #77. Also, there seems to be potential to extract more macros. I will raise a separate PR for this. 